### PR TITLE
refactor: replace Tailwind gray palette with zinc

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-900 text-white p-4 flex flex-col md:flex-row gap-4">
+      <div className="min-h-screen bg-zinc-900 text-white p-4 flex flex-col md:flex-row gap-4">
       <div className="flex-1 flex flex-col items-center">
         <h1 className="text-3xl font-bold mb-2">Ask GM ♟️</h1>
         <PersonalitySelector selected={selectedGM} onSelect={setSelectedGM} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,44 +25,49 @@ function App() {
   const handleReset = () => {
     setMove("");
     setExplanation("");
-    // Add chessboard reset logic here
+    // TODO: Add chessboard reset logic here
   };
 
   const handleQuestion = async (question: string) => {
-    // Placeholder: log FEN, selectedGM, question
     setThinking(true);
+
     setChatMessages((msgs) => [
       ...msgs,
       { sender: "You", text: question },
     ]);
+
     // Simulate GPT response
     setTimeout(() => {
       setChatMessages((msgs) => [
         ...msgs,
-        { sender: "GM", text: `(${selectedGM}): That's a great question! [Sample answer here.]` },
+        {
+          sender: "GM",
+          text: `(${selectedGM}): That's a great question! [Sample answer here.]`,
+        },
       ]);
       setThinking(false);
-    }, 1100); // Simulate thinking time, 1.1 seconds
+    }, 1100);
   };
 
   return (
-      <div className="min-h-screen bg-zinc-900 text-white p-4 flex flex-col md:flex-row gap-4">
+    <div className="min-h-screen bg-gray-900 text-white p-4 flex flex-col md:flex-row gap-4">
       <div className="flex-1 flex flex-col items-center">
         <h1 className="text-3xl font-bold mb-2">Ask GM ♟️</h1>
         <PersonalitySelector selected={selectedGM} onSelect={setSelectedGM} />
         <div className="w-full max-w-[480px]">
           <ChessPanel
             position=""
-            onMove={() => { }}
-            onBack={() => { }}
-            onForward={() => { }}
-            onUndo={() => { }}
+            onMove={() => {}}
+            onBack={() => {}}
+            onForward={() => {}}
+            onUndo={() => {}}
             onAsk={handleAnalyze}
             selectedGM={selectedGM}
             disableForward={true}
           />
         </div>
       </div>
+
       <div className="w-full md:w-[400px] flex flex-col">
         <ChatWindow
           messages={chatMessages}

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -31,7 +31,7 @@ const ChatWindow = ({ messages, onSubmit, thinking }: ChatWindowProps) => {
         {messages.map((msg, i) => (
           <div
             key={i}
-            className={`px-3 py-2 rounded max-w-[90%] ${msg.sender === "You" ? "bg-blue-700 self-end text-right" : "bg-zinc-700 self-start"
+            className={`px-3 py-2 rounded max-w-[90%] ${msg.sender === "You" ? "bg-blue-700 self-end text-right" : "bg-gray-900 self-start"
               }`}
           >
             <span className="block text-sm">{msg.text}</span>
@@ -41,7 +41,7 @@ const ChatWindow = ({ messages, onSubmit, thinking }: ChatWindowProps) => {
         <div ref={bottomRef} />
         {/* Thinking indicator */}
         {thinking && (
-          <div className="px-3 py-2 rounded max-w-[90%] bg-zinc-700 self-start animate-pulse text-sm text-zinc-300">
+          <div className="px-3 py-2 rounded max-w-[90%] bg-gray-900 self-start animate-pulse text-sm text-zinc-300">
             Thinking...
           </div>
         )}
@@ -51,7 +51,7 @@ const ChatWindow = ({ messages, onSubmit, thinking }: ChatWindowProps) => {
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && handleSend()}
-          className="flex-1 bg-zinc-700 text-white p-2 rounded"
+          className="flex-1 bg-gray-900 text-white p-2 rounded"
           placeholder="Ask a question..."
         />
         <button onClick={handleSend} className="btn">

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -26,12 +26,12 @@ const ChatWindow = ({ messages, onSubmit, thinking }: ChatWindowProps) => {
   };
 
   return (
-    <div className="flex flex-col border-4 border-gray-600 rounded-xl p-4 bg-gray-800 h-full">
+    <div className="flex flex-col border-4 border-zinc-600 rounded-xl p-4 bg-zinc-800 h-full">
       <div className="flex-1 overflow-y-auto mb-4 space-y-2">
         {messages.map((msg, i) => (
           <div
             key={i}
-            className={`px-3 py-2 rounded max-w-[90%] ${msg.sender === "You" ? "bg-blue-700 self-end text-right" : "bg-gray-700 self-start"
+            className={`px-3 py-2 rounded max-w-[90%] ${msg.sender === "You" ? "bg-blue-700 self-end text-right" : "bg-zinc-700 self-start"
               }`}
           >
             <span className="block text-sm">{msg.text}</span>
@@ -41,7 +41,7 @@ const ChatWindow = ({ messages, onSubmit, thinking }: ChatWindowProps) => {
         <div ref={bottomRef} />
         {/* Thinking indicator */}
         {thinking && (
-          <div className="px-3 py-2 rounded max-w-[90%] bg-gray-700 self-start animate-pulse text-sm text-gray-300">
+          <div className="px-3 py-2 rounded max-w-[90%] bg-zinc-700 self-start animate-pulse text-sm text-zinc-300">
             Thinking...
           </div>
         )}
@@ -51,7 +51,7 @@ const ChatWindow = ({ messages, onSubmit, thinking }: ChatWindowProps) => {
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && handleSend()}
-          className="flex-1 bg-gray-700 text-white p-2 rounded"
+          className="flex-1 bg-zinc-700 text-white p-2 rounded"
           placeholder="Ask a question..."
         />
         <button onClick={handleSend} className="btn">

--- a/src/components/ChessBoard.tsx
+++ b/src/components/ChessBoard.tsx
@@ -9,8 +9,8 @@ interface ChessBoardProps {
 
 const ChessBoard: React.FC<ChessBoardProps> = ({ position, onMove }) => {
   // The parent manages the game state and passes FEN and onMove
-  return (
-    <div className="rounded-lg shadow-lg p-2 bg-gray-800 w-[400px]">
+    return (
+      <div className="rounded-lg shadow-lg p-2 bg-zinc-800 w-[400px]">
     <Chessboard
       position={position}
       onPieceDrop={(sourceSquare, targetSquare) => {

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -8,18 +8,18 @@ interface ControlPanelProps {
 const ControlPanel: React.FC<ControlPanelProps> = ({ onAnalyze, onReset }) => {
   return (
     <div className="flex gap-4 justify-center mt-4">
-      <button
-        className="px-6 py-2 rounded-lg bg-blue-600 text-white font-semibold hover:bg-blue-700 transition-colors duration-200 shadow"
-        onClick={onAnalyze}
-      >
-        Analyze Position
-      </button>
-      <button
-        className="px-6 py-2 rounded-lg bg-gray-700 text-white font-semibold hover:bg-gray-800 transition-colors duration-200 shadow"
-        onClick={onReset}
-      >
-        Reset
-      </button>
+        <button
+          className="px-6 py-2 rounded-lg bg-blue-600 text-white font-semibold hover:bg-blue-700 transition-colors duration-200 shadow"
+          onClick={onAnalyze}
+        >
+          Analyze Position
+        </button>
+        <button
+          className="px-6 py-2 rounded-lg bg-zinc-700 text-white font-semibold hover:bg-zinc-800 transition-colors duration-200 shadow"
+          onClick={onReset}
+        >
+          Reset
+        </button>
     </div>
   );
 };

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -15,7 +15,7 @@ const ControlPanel: React.FC<ControlPanelProps> = ({ onAnalyze, onReset }) => {
           Analyze Position
         </button>
         <button
-          className="px-6 py-2 rounded-lg bg-zinc-700 text-white font-semibold hover:bg-zinc-800 transition-colors duration-200 shadow"
+          className="px-6 py-2 rounded-lg bg-gray-900 text-white font-semibold hover:bg-zinc-800 transition-colors duration-200 shadow"
           onClick={onReset}
         >
           Reset

--- a/src/components/MoveAnalysis.tsx
+++ b/src/components/MoveAnalysis.tsx
@@ -7,7 +7,7 @@ interface MoveAnalysisProps {
 
 const MoveAnalysis: React.FC<MoveAnalysisProps> = ({ move, explanation }) => {
   return (
-    <div className="bg-gray-900 text-white rounded-lg p-4 shadow-md mt-4">
+    <div className="bg-zinc-900 text-white rounded-lg p-4 shadow-md mt-4">
       <h2 className="text-lg font-bold mb-2">Best Move: <span className="text-blue-400">{move}</span></h2>
       <p className="italic">{explanation}</p>
     </div>

--- a/src/components/PersonalitySelector.tsx
+++ b/src/components/PersonalitySelector.tsx
@@ -13,7 +13,7 @@ const PersonalitySelector: React.FC<PersonalitySelectorProps> = ({ selected, onS
       {personalities.map((name) => (
         <button
           key={name}
-          className={`px-4 py-2 rounded-lg font-semibold transition-colors duration-200 bg-gray-700 text-white hover:bg-gray-600 ${selected === name ? "border-2 border-blue-500" : ""}`}
+            className={`px-4 py-2 rounded-lg font-semibold transition-colors duration-200 bg-zinc-700 text-white hover:bg-zinc-600 ${selected === name ? "border-2 border-blue-500" : ""}`}
           onClick={() => onSelect(name)}
         >
           {name}

--- a/src/components/PersonalitySelector.tsx
+++ b/src/components/PersonalitySelector.tsx
@@ -13,7 +13,7 @@ const PersonalitySelector: React.FC<PersonalitySelectorProps> = ({ selected, onS
       {personalities.map((name) => (
         <button
           key={name}
-            className={`px-4 py-2 rounded-lg font-semibold transition-colors duration-200 bg-zinc-700 text-white hover:bg-zinc-600 ${selected === name ? "border-2 border-blue-500" : ""}`}
+            className={`px-4 py-2 rounded-lg font-semibold transition-colors duration-200 bg-gray-900 text-white hover:bg-zinc-600 ${selected === name ? "border-2 border-blue-500" : ""}`}
           onClick={() => onSelect(name)}
         >
           {name}

--- a/src/features/ChessPanel.tsx
+++ b/src/features/ChessPanel.tsx
@@ -23,7 +23,7 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
   disableForward,
 }) => {
   return (
-    <div className="border-4 border-gray-600 rounded-xl p-4 shadow-xl bg-gray-800 w-full max-w-[480px]">
+      <div className="border-4 border-zinc-600 rounded-xl p-4 shadow-xl bg-zinc-800 w-full max-w-[480px]">
       <ChessBoard position={position} onMove={onMove} />
       <div className="flex justify-between mt-4 gap-2">
         <button onClick={onBack} className="btn">← Back</button>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,3 @@
 @tailwind components;
 @tailwind utilities;
 
-.btn {
-  @apply bg-zinc-700 text-white px-3 py-1 rounded hover:bg-zinc-600;
-}

--- a/src/index.css
+++ b/src/index.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 .btn {
-  @apply bg-gray-700 text-white px-3 py-1 rounded hover:bg-gray-600;
+  @apply bg-zinc-700 text-white px-3 py-1 rounded hover:bg-zinc-600;
 }


### PR DESCRIPTION
## Summary
- replace deprecated Tailwind `gray` utilities with `zinc`
- update custom `.btn` and all components to use the `zinc` color family

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6892ac23d54883339666525a31abd334