### PR TITLE
Add playable demo chess flow with history, keyboard navigation, and demo chat reply

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,61 @@
-import React, { useState } from "react";
-import ChessBoard from "./components/ChessBoard";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Chess } from "chess.js";
 import PersonalitySelector from "./components/PersonalitySelector";
-import MoveAnalysis from "./components/MoveAnalysis";
-import ControlPanel from "./components/ControlPanel";
 import ChatWindow from "./components/ChatWindow";
 import ChessPanel from "./features/ChessPanel";
 
 function App() {
   const [selectedGM, setSelectedGM] = useState("Magnus");
-  const [move, setMove] = useState("");
-  const [explanation, setExplanation] = useState("");
   const [chatMessages, setChatMessages] = useState([
     { sender: "GM", text: "Welcome! Ask me anything about this position." },
   ]);
   const [thinking, setThinking] = useState(false);
+  const chessRef = useRef(new Chess());
+  const [history, setHistory] = useState([chessRef.current.fen()]);
+  const [historyIndex, setHistoryIndex] = useState(0);
+  const [currentFen, setCurrentFen] = useState(chessRef.current.fen());
 
-  const handleAnalyze = () => {
-    setMove("Nf3");
-    setExplanation(
-      `${selectedGM} says: This keeps pressure while simplifying the position.`
-    );
+  const loadFenAt = useCallback(
+    (index: number) => {
+      const boundedIndex = Math.min(Math.max(index, 0), history.length - 1);
+      const fen = history[boundedIndex];
+      chessRef.current.load(fen);
+      setHistoryIndex(boundedIndex);
+      setCurrentFen(fen);
+    },
+    [history],
+  );
+
+  const handleMove = (from: string, to: string) => {
+    const move = chessRef.current.move({ from, to, promotion: "q" });
+    if (!move) {
+      return false;
+    }
+    const fen = chessRef.current.fen();
+    const nextHistory = history.slice(0, historyIndex + 1).concat(fen);
+    setHistory(nextHistory);
+    setHistoryIndex(nextHistory.length - 1);
+    setCurrentFen(fen);
+    return true;
   };
 
-  const handleReset = () => {
-    setMove("");
-    setExplanation("");
-    // TODO: Add chessboard reset logic here
-  };
+  const handleBack = useCallback(() => {
+    if (historyIndex > 0) {
+      loadFenAt(historyIndex - 1);
+    }
+  }, [historyIndex, loadFenAt]);
 
-  const handleQuestion = async (question: string) => {
+  const handleForward = useCallback(() => {
+    if (historyIndex < history.length - 1) {
+      loadFenAt(historyIndex + 1);
+    }
+  }, [history.length, historyIndex, loadFenAt]);
+
+  const handleUndo = useCallback(() => {
+    handleBack();
+  }, [handleBack]);
+
+  const handleQuestion = (question: string) => {
     setThinking(true);
 
     setChatMessages((msgs) => [
@@ -36,18 +63,49 @@ function App() {
       { sender: "You", text: question },
     ]);
 
-    // Simulate GPT response
-    setTimeout(() => {
+    window.setTimeout(() => {
       setChatMessages((msgs) => [
         ...msgs,
         {
           sender: "GM",
-          text: `(${selectedGM}): That's a great question! [Sample answer here.]`,
+          text: "GM Conversation is not yet fully implemented.",
         },
       ]);
       setThinking(false);
-    }, 1100);
+    }, 500);
   };
+
+  const handleQuickAsk = () => {
+    handleQuestion("What should I play here?");
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const tagName = target?.tagName?.toLowerCase();
+      const isEditable =
+        tagName === "input" ||
+        tagName === "textarea" ||
+        tagName === "select" ||
+        target?.isContentEditable;
+
+      if (isEditable) {
+        return;
+      }
+
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        handleBack();
+      }
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        handleForward();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleBack, handleForward]);
 
   return (
     <div className="min-h-screen bg-gray-900 text-white p-4 flex flex-col md:flex-row gap-4">
@@ -56,14 +114,14 @@ function App() {
         <PersonalitySelector selected={selectedGM} onSelect={setSelectedGM} />
         <div className="w-full max-w-[480px]">
           <ChessPanel
-            position=""
-            onMove={() => {}}
-            onBack={() => {}}
-            onForward={() => {}}
-            onUndo={() => {}}
-            onAsk={handleAnalyze}
+            position={currentFen}
+            onMove={handleMove}
+            onBack={handleBack}
+            onForward={handleForward}
+            onUndo={handleUndo}
+            onAsk={handleQuickAsk}
             selectedGM={selectedGM}
-            disableForward={true}
+            disableForward={historyIndex >= history.length - 1}
           />
         </div>
       </div>

--- a/src/components/ChessBoard.tsx
+++ b/src/components/ChessBoard.tsx
@@ -3,7 +3,7 @@ import { Chessboard } from "react-chessboard";
 
 interface ChessBoardProps {
   position: string;
-  onMove: (from: string, to: string) => void;
+  onMove: (from: string, to: string) => boolean;
   onFenChange?: (fen: string) => void;
 }
 
@@ -14,8 +14,7 @@ const ChessBoard: React.FC<ChessBoardProps> = ({ position, onMove }) => {
     <Chessboard
       position={position}
       onPieceDrop={(sourceSquare, targetSquare) => {
-        onMove(sourceSquare, targetSquare);
-        return true;
+        return onMove(sourceSquare, targetSquare);
       }}
     />
     </div>
@@ -23,4 +22,3 @@ const ChessBoard: React.FC<ChessBoardProps> = ({ position, onMove }) => {
 };
 
 export default ChessBoard;
-

--- a/src/components/PersonalitySelector.tsx
+++ b/src/components/PersonalitySelector.tsx
@@ -9,16 +9,22 @@ interface PersonalitySelectorProps {
 
 const PersonalitySelector: React.FC<PersonalitySelectorProps> = ({ selected, onSelect }) => {
   return (
-    <div className="flex gap-4 justify-center mb-4">
-      {personalities.map((name) => (
-        <button
-          key={name}
-            className={`px-4 py-2 rounded-lg font-semibold transition-colors duration-200 bg-gray-900 text-white hover:bg-zinc-600 ${selected === name ? "border-2 border-blue-500" : ""}`}
-          onClick={() => onSelect(name)}
-        >
-          {name}
-        </button>
-      ))}
+    <div className="flex flex-col items-center gap-2 mb-4 w-full max-w-[320px]">
+      <label className="text-sm font-semibold text-zinc-300" htmlFor="gm-selector">
+        Select GM Persona
+      </label>
+      <select
+        id="gm-selector"
+        className="w-full rounded-lg bg-gray-900 text-white px-4 py-2 border border-zinc-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        value={selected}
+        onChange={(event) => onSelect(event.target.value)}
+      >
+        {personalities.map((name) => (
+          <option key={name} value={name}>
+            {name}
+          </option>
+        ))}
+      </select>
     </div>
   );
 };

--- a/src/features/ChessPanel.tsx
+++ b/src/features/ChessPanel.tsx
@@ -3,7 +3,7 @@ import ChessBoard from "../components/ChessBoard";
 
 interface ChessPanelProps {
   position: string;
-  onMove: (from: string, to: string) => void;
+  onMove: (from: string, to: string) => boolean;
   onBack: () => void;
   onForward: () => void;
   onUndo: () => void;

--- a/src/index.css
+++ b/src/index.css
@@ -2,3 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .btn {
+    @apply rounded-lg bg-zinc-700 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-zinc-600 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a functioning demo so users can move chess pieces under the rules, browse move history with arrow keys, and ask questions in the chat with a safe default reply. 
- Keep surface area small and UI-ready for future GPT/Stockfish integration by wiring the canonical game state to a single source of truth. 

### Description
- Wire up `chess.js` state and a history model (`history`, `historyIndex`, `currentFen`) and expose `handleMove(from,to)` that applies legal moves and returns a boolean success value, with changes in `src/App.tsx` and `src/components/ChessBoard.tsx`. 
- Make the chessboard return move legality by propagating the boolean from `Chessboard.onPieceDrop`, and update `ChessPanel` prop types to accept the boolean-returning `onMove` in `src/features/ChessPanel.tsx`. 
- Add keyboard navigation for history (`ArrowLeft`/`ArrowRight`) and simple undo/forward actions, plus a quick sample `handleQuickAsk` that appends a default GM reply text (`"GM Conversation is not yet fully implemented."`) in `src/App.tsx`. 
- Replace the GM persona buttons with a labeled dropdown selector in `src/components/PersonalitySelector.tsx` and add a shared `.btn` Tailwind component in `src/index.css` for consistent control styling. 

### Testing
- Ran dependency installation with `npm install` and `npm install --legacy-peer-deps`, but the install encountered dependency/rename errors and produced an incomplete `node_modules`, preventing a full test run. (failed)
- Attempted to start the dev server with `npm run dev`, but `vite` was not available in the environment due to the install issues, so the app could not be launched for an end-to-end verification. (failed)
- No automated unit tests were added or executed as part of this change because the local dev server could not be started.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697532dbe2e08333babfd72086476b5f)