### PR TITLE
Fix Express 5 wildcard route syntax for SPA catch-all

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -133,7 +133,7 @@ app.get("/api/health", (_req, res) => {
 });
 
 if (process.env.NODE_ENV === "production") {
-  app.get("*", (_req, res) => {
+  app.get("/{*path}", (_req, res) => {
     res.sendFile(path.join(__dirname, "../dist", "index.html"));
   });
 }


### PR DESCRIPTION
Express 5 uses path-to-regexp v8+ which rejects bare '*'. Use '/{*path}' named wildcard syntax instead.