### PR TITLE
Add opening lessons panel with move-by-move study and engine analysis

### DIFF
--- a/src/components/CapturedPieces.tsx
+++ b/src/components/CapturedPieces.tsx
@@ -1,0 +1,94 @@
+import React, { useMemo } from "react";
+import { Chess } from "chess.js";
+
+// Piece values for material advantage calculation
+const PIECE_VALUES: Record<string, number> = {
+  p: 1, n: 3, b: 3, r: 5, q: 9, k: 0,
+};
+
+// Unicode chess symbols
+const WHITE_SYMBOLS: Record<string, string> = {
+  q: "♕", r: "♖", b: "♗", n: "♘", p: "♙",
+};
+const BLACK_SYMBOLS: Record<string, string> = {
+  q: "♛", r: "♜", b: "♝", n: "♞", p: "♟",
+};
+
+// Starting piece counts per color
+const STARTING: Record<string, number> = { p: 8, n: 2, b: 2, r: 2, q: 1 };
+const PIECE_ORDER = ["q", "r", "b", "n", "p"] as const;
+
+function computeCaptured(fen: string) {
+  const chess = new Chess(fen);
+  const onBoard: Record<string, Record<string, number>> = {
+    w: { p: 0, n: 0, b: 0, r: 0, q: 0 },
+    b: { p: 0, n: 0, b: 0, r: 0, q: 0 },
+  };
+
+  for (const row of chess.board()) {
+    for (const piece of row) {
+      if (piece && piece.type !== "k") {
+        onBoard[piece.color][piece.type]++;
+      }
+    }
+  }
+
+  // Pieces captured BY white = missing black pieces
+  const capturedByWhite: string[] = [];
+  // Pieces captured BY black = missing white pieces
+  const capturedByBlack: string[] = [];
+  let materialAdvantage = 0;
+
+  for (const type of PIECE_ORDER) {
+    const missingBlack = STARTING[type] - onBoard.b[type];
+    const missingWhite = STARTING[type] - onBoard.w[type];
+    for (let i = 0; i < missingBlack; i++) capturedByWhite.push(type);
+    for (let i = 0; i < missingWhite; i++) capturedByBlack.push(type);
+    materialAdvantage += (missingBlack - missingWhite) * PIECE_VALUES[type];
+  }
+
+  return { capturedByWhite, capturedByBlack, materialAdvantage };
+}
+
+interface CapturedPiecesProps {
+  fen: string;
+  /** "top" = shown above board (black's captures of white pieces; from black's side) */
+  side: "top" | "bottom";
+}
+
+const CapturedPieces: React.FC<CapturedPiecesProps> = ({ fen, side }) => {
+  const { capturedByWhite, capturedByBlack, materialAdvantage } = useMemo(
+    () => computeCaptured(fen),
+    [fen]
+  );
+
+  // "top" row shows captures made by Black (white pieces taken)
+  // "bottom" row shows captures made by White (black pieces taken)
+  const pieces = side === "top" ? capturedByBlack : capturedByWhite;
+  const symbols = side === "top" ? WHITE_SYMBOLS : BLACK_SYMBOLS;
+
+  // Material advantage sign: positive = white ahead, negative = black ahead
+  const showAdvantage =
+    side === "bottom" && materialAdvantage > 0
+      ? `+${materialAdvantage}`
+      : side === "top" && materialAdvantage < 0
+      ? `+${Math.abs(materialAdvantage)}`
+      : null;
+
+  return (
+    <div className="flex items-center gap-1 min-h-[22px] px-1">
+      <span className="text-lg leading-none tracking-tight">
+        {pieces.map((type, i) => (
+          <span key={i} className={side === "top" ? "text-zinc-200" : "text-zinc-300"}>
+            {symbols[type]}
+          </span>
+        ))}
+      </span>
+      {showAdvantage && (
+        <span className="text-xs font-bold text-zinc-400 ml-1">{showAdvantage}</span>
+      )}
+    </div>
+  );
+};
+
+export default CapturedPieces;

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -26,35 +26,45 @@ const ChatWindow = ({ messages, onSubmit, thinking }: ChatWindowProps) => {
   };
 
   return (
-    <div className="flex flex-col border-4 border-zinc-600 rounded-xl p-4 bg-zinc-800 h-full">
-      <div className="flex-1 overflow-y-auto mb-4 space-y-2">
+    <div className="flex flex-col border-4 border-zinc-600 rounded-xl p-4 bg-zinc-800 h-full min-h-0">
+      <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-wide mb-2">Chat with GM</h2>
+      <div className="flex-1 overflow-y-auto min-h-0 mb-3 space-y-2 pr-1">
         {messages.map((msg, i) => (
           <div
             key={i}
-            className={`px-3 py-2 rounded max-w-[90%] ${msg.sender === "You" ? "bg-blue-700 self-end text-right" : "bg-gray-900 self-start"
-              }`}
+            className={`flex ${msg.sender === "You" ? "justify-end" : "justify-start"}`}
           >
-            <span className="block text-sm">{msg.text}</span>
+            <div
+              className={`px-3 py-2 rounded-lg max-w-[85%] text-sm leading-relaxed ${
+                msg.sender === "You"
+                  ? "bg-blue-600 text-white"
+                  : "bg-zinc-700 text-zinc-100"
+              }`}
+            >
+              {msg.text}
+            </div>
           </div>
         ))}
-        {/* Bottom reference so that we can auto-scroll to bottom */}
-        <div ref={bottomRef} />
         {/* Thinking indicator */}
         {thinking && (
-          <div className="px-3 py-2 rounded max-w-[90%] bg-gray-900 self-start animate-pulse text-sm text-zinc-300">
-            Thinking...
+          <div className="flex justify-start">
+            <div className="px-3 py-2 rounded-lg bg-zinc-700 text-zinc-400 text-sm animate-pulse">
+              Thinking...
+            </div>
           </div>
         )}
+        {/* Bottom anchor for auto-scroll */}
+        <div ref={bottomRef} />
       </div>
-      <div className="flex gap-2">
+      <div className="flex gap-2 mt-auto">
         <input
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && handleSend()}
-          className="flex-1 bg-gray-900 text-white p-2 rounded"
+          className="flex-1 bg-zinc-900 text-white p-2 rounded-lg border border-zinc-600 focus:outline-none focus:ring-1 focus:ring-blue-500 text-sm"
           placeholder="Ask a question..."
         />
-        <button onClick={handleSend} className="btn">
+        <button onClick={handleSend} className="btn text-sm px-4">
           Send
         </button>
       </div>

--- a/src/components/EvalBar.tsx
+++ b/src/components/EvalBar.tsx
@@ -1,0 +1,91 @@
+import React, { useMemo } from "react";
+
+interface EvalBarProps {
+  /** Centipawns from white's perspective (±9999 for forced mate). Null = unknown. */
+  evalScore: number | null;
+  /** Forced mate in N moves (positive = white wins, negative = black wins). Null if none. */
+  mateIn: number | null;
+  /** Whether Stockfish is still analysing. */
+  thinking: boolean;
+}
+
+/**
+ * Convert centipawn score to a percentage (0–100) for the white portion of the bar.
+ * 50 = equal; uses tanh so extremes are smoothly clamped.
+ */
+function cpToPercent(cp: number): number {
+  return 50 + 50 * Math.tanh(cp / 400);
+}
+
+const EvalBar: React.FC<EvalBarProps> = ({ evalScore, mateIn, thinking }) => {
+  const { whitePercent, label } = useMemo(() => {
+    if (evalScore === null) return { whitePercent: 50, label: "=" };
+
+    if (mateIn !== null) {
+      const isWhiteWin = mateIn > 0;
+      return {
+        whitePercent: isWhiteWin ? 97 : 3,
+        label: `M${Math.abs(mateIn)}`,
+      };
+    }
+
+    const pct = cpToPercent(evalScore);
+    const abs = Math.abs(evalScore);
+    const pawns = (abs / 100).toFixed(abs >= 100 ? 1 : 2);
+    const sign = evalScore > 0 ? "+" : evalScore < 0 ? "-" : "";
+    const label = evalScore === 0 ? "0.00" : `${sign}${pawns}`;
+    return { whitePercent: pct, label };
+  }, [evalScore, mateIn]);
+
+  const blackPercent = 100 - whitePercent;
+
+  return (
+    <div className="flex flex-col items-center gap-1 select-none" title="Engine evaluation">
+      {/* Vertical bar (desktop) */}
+      <div className="hidden md:flex flex-col w-5 rounded overflow-hidden shadow-inner border border-zinc-600"
+        style={{ height: 480 }}>
+        {/* Black portion (top) */}
+        <div
+          className="bg-zinc-900 transition-all duration-500"
+          style={{ height: `${blackPercent}%` }}
+        />
+        {/* White portion (bottom) */}
+        <div
+          className="bg-zinc-100 transition-all duration-500"
+          style={{ height: `${whitePercent}%` }}
+        />
+      </div>
+
+      {/* Horizontal bar (mobile) */}
+      <div className="flex md:hidden w-full h-4 rounded overflow-hidden shadow-inner border border-zinc-600">
+        {/* White portion (left) */}
+        <div
+          className="bg-zinc-100 transition-all duration-500"
+          style={{ width: `${whitePercent}%` }}
+        />
+        {/* Black portion (right) */}
+        <div
+          className="bg-zinc-900 transition-all duration-500"
+          style={{ width: `${blackPercent}%` }}
+        />
+      </div>
+
+      {/* Score label */}
+      <div
+        className={`text-xs font-mono font-bold tabular-nums transition-opacity ${
+          thinking ? "opacity-40" : "opacity-100"
+        } ${
+          evalScore !== null && evalScore > 0
+            ? "text-zinc-100"
+            : evalScore !== null && evalScore < 0
+            ? "text-zinc-400"
+            : "text-zinc-400"
+        }`}
+      >
+        {thinking && evalScore === null ? "..." : label}
+      </div>
+    </div>
+  );
+};
+
+export default EvalBar;

--- a/src/components/OpeningsPanel.tsx
+++ b/src/components/OpeningsPanel.tsx
@@ -1,0 +1,297 @@
+import React, { useState, useEffect, useCallback, useRef } from "react";
+import { Chess } from "chess.js";
+import { OPENINGS, CATEGORIES, type Opening } from "../data/openings";
+
+interface OpeningsPanelProps {
+  /** Called when the user enters an opening lesson so we can update the board */
+  onPositionChange: (fen: string, moveIndex: number, opening: Opening) => void;
+  /** Called when user exits the lesson */
+  onExit: () => void;
+  /** Current lesson step set externally (for keyboard nav sync) */
+  currentStep: number;
+  onStepChange: (step: number) => void;
+  /** Active opening (null = browse mode) */
+  activeOpening: Opening | null;
+  onSelectOpening: (opening: Opening) => void;
+}
+
+function getInitialFen(): string {
+  return new Chess().fen();
+}
+
+function getFenAtStep(moves: string[], step: number): string {
+  const chess = new Chess();
+  for (let i = 0; i <= step && i < moves.length; i++) {
+    const m = moves[i];
+    chess.move({ from: m.slice(0, 2), to: m.slice(2, 4), promotion: m[4] ?? "q" });
+  }
+  return chess.fen();
+}
+
+/** Convert UCI move list to human-readable SAN with move numbers */
+function formatMoves(moves: string[]): { number: number; white: string; black: string | null }[] {
+  const chess = new Chess();
+  const result: { number: number; white: string; black: string | null }[] = [];
+  for (let i = 0; i < moves.length; i += 2) {
+    const m = moves[i];
+    const white = chess.move({ from: m.slice(0, 2), to: m.slice(2, 4), promotion: m[4] ?? "q" });
+    let black: string | null = null;
+    if (i + 1 < moves.length) {
+      const mb = moves[i + 1];
+      const bMove = chess.move({ from: mb.slice(0, 2), to: mb.slice(2, 4), promotion: mb[4] ?? "q" });
+      black = bMove?.san ?? null;
+    }
+    result.push({ number: i / 2 + 1, white: white?.san ?? m, black });
+  }
+  return result;
+}
+
+const OpeningsPanel: React.FC<OpeningsPanelProps> = ({
+  onPositionChange,
+  onExit,
+  currentStep,
+  onStepChange,
+  activeOpening,
+  onSelectOpening,
+}) => {
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [isAnimating, setIsAnimating] = useState(false);
+  const animRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // When active opening changes, broadcast position
+  useEffect(() => {
+    if (!activeOpening) return;
+    const fen =
+      currentStep < 0
+        ? getInitialFen()
+        : getFenAtStep(activeOpening.moves, currentStep);
+    onPositionChange(fen, currentStep, activeOpening);
+  }, [activeOpening, currentStep, onPositionChange]);
+
+  const handleSelectOpening = useCallback(
+    (opening: Opening) => {
+      onSelectOpening(opening);
+      onStepChange(-1);
+    },
+    [onSelectOpening, onStepChange]
+  );
+
+  const handlePrev = useCallback(() => {
+    if (!activeOpening) return;
+    onStepChange(Math.max(-1, currentStep - 1));
+  }, [activeOpening, currentStep, onStepChange]);
+
+  const handleNext = useCallback(() => {
+    if (!activeOpening) return;
+    onStepChange(Math.min(activeOpening.moves.length - 1, currentStep + 1));
+  }, [activeOpening, currentStep, onStepChange]);
+
+  const handleAnimate = useCallback(() => {
+    if (!activeOpening || isAnimating) return;
+    setIsAnimating(true);
+    onStepChange(-1);
+
+    let step = -1;
+    const tick = () => {
+      step++;
+      onStepChange(step);
+      if (step < activeOpening.moves.length - 1) {
+        animRef.current = setTimeout(tick, 800);
+      } else {
+        setIsAnimating(false);
+      }
+    };
+    animRef.current = setTimeout(tick, 600);
+  }, [activeOpening, isAnimating, onStepChange]);
+
+  const handleStopAnimate = useCallback(() => {
+    if (animRef.current) clearTimeout(animRef.current);
+    setIsAnimating(false);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (animRef.current) clearTimeout(animRef.current);
+    };
+  }, []);
+
+  // Filter openings
+  const filtered = OPENINGS.filter((o) => {
+    const matchCategory = !selectedCategory || o.category === selectedCategory;
+    const matchSearch =
+      !search ||
+      o.name.toLowerCase().includes(search.toLowerCase()) ||
+      o.eco.toLowerCase().includes(search.toLowerCase());
+    return matchCategory && matchSearch;
+  });
+
+  // ── Lesson view ─────────────────────────────────────────────────
+  if (activeOpening) {
+    const movePairs = formatMoves(activeOpening.moves);
+    const totalSteps = activeOpening.moves.length;
+    const progress = currentStep + 1; // -1 = start = 0 moves shown
+
+    return (
+      <div className="flex flex-col h-full">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-3 gap-2">
+          <button
+            onClick={onExit}
+            className="text-zinc-400 hover:text-white text-sm flex items-center gap-1"
+          >
+            ← Back
+          </button>
+          <div className="text-center flex-1">
+            <div className="text-xs text-zinc-500 font-mono">{activeOpening.eco}</div>
+            <div className="font-semibold text-sm text-white">{activeOpening.name}</div>
+          </div>
+          <div className="text-xs text-zinc-500 tabular-nums">
+            {Math.max(0, progress)}/{totalSteps}
+          </div>
+        </div>
+
+        {/* Description */}
+        <p className="text-xs text-zinc-400 leading-relaxed mb-3">{activeOpening.description}</p>
+
+        {/* Move list */}
+        <div className="flex-1 overflow-y-auto min-h-0 mb-3">
+          <div className="grid gap-0.5">
+            {movePairs.map((pair, i) => {
+              const whiteIdx = i * 2;
+              const blackIdx = i * 2 + 1;
+              return (
+                <div key={i} className="flex items-center gap-1 text-sm font-mono">
+                  <span className="text-zinc-600 w-6 text-right shrink-0">{pair.number}.</span>
+                  <button
+                    onClick={() => onStepChange(whiteIdx)}
+                    className={`px-2 py-0.5 rounded transition-colors ${
+                      currentStep === whiteIdx
+                        ? "bg-blue-600 text-white"
+                        : "text-zinc-300 hover:bg-zinc-700"
+                    }`}
+                  >
+                    {pair.white}
+                  </button>
+                  {pair.black !== null && (
+                    <button
+                      onClick={() => onStepChange(blackIdx)}
+                      className={`px-2 py-0.5 rounded transition-colors ${
+                        currentStep === blackIdx
+                          ? "bg-blue-600 text-white"
+                          : "text-zinc-300 hover:bg-zinc-700"
+                      }`}
+                    >
+                      {pair.black}
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Controls */}
+        <div className="flex gap-2 flex-wrap">
+          <button className="btn text-xs" onClick={handlePrev} disabled={currentStep < 0}>
+            ← Prev
+          </button>
+          <button
+            className="btn text-xs"
+            onClick={handleNext}
+            disabled={currentStep >= totalSteps - 1}
+          >
+            Next →
+          </button>
+          {isAnimating ? (
+            <button className="btn text-xs bg-red-700 hover:bg-red-600" onClick={handleStopAnimate}>
+              Stop
+            </button>
+          ) : (
+            <button
+              className="btn text-xs bg-green-700 hover:bg-green-600"
+              onClick={handleAnimate}
+              disabled={isAnimating}
+            >
+              ▶ Animate
+            </button>
+          )}
+        </div>
+        <p className="text-xs text-zinc-500 mt-2">
+          Tip: Use the chat to ask your GM about this opening!
+        </p>
+      </div>
+    );
+  }
+
+  // ── Browse view ──────────────────────────────────────────────────
+  return (
+    <div className="flex flex-col h-full">
+      <div className="mb-3">
+        <h2 className="font-bold text-white text-base mb-1">Opening Lessons</h2>
+        <p className="text-xs text-zinc-400">
+          Select an opening to study it move by move and ask your GM.
+        </p>
+      </div>
+
+      {/* Search */}
+      <input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search openings..."
+        className="w-full bg-zinc-900 text-white text-sm p-2 rounded-lg border border-zinc-600 focus:outline-none focus:ring-1 focus:ring-blue-500 mb-2"
+      />
+
+      {/* Category filters */}
+      <div className="flex flex-wrap gap-1 mb-3">
+        <button
+          onClick={() => setSelectedCategory(null)}
+          className={`text-xs px-2 py-1 rounded-full border transition-colors ${
+            !selectedCategory
+              ? "bg-blue-600 border-blue-600 text-white"
+              : "border-zinc-600 text-zinc-400 hover:border-zinc-400"
+          }`}
+        >
+          All
+        </button>
+        {CATEGORIES.map((cat) => (
+          <button
+            key={cat}
+            onClick={() => setSelectedCategory(selectedCategory === cat ? null : cat)}
+            className={`text-xs px-2 py-1 rounded-full border transition-colors ${
+              selectedCategory === cat
+                ? "bg-blue-600 border-blue-600 text-white"
+                : "border-zinc-600 text-zinc-400 hover:border-zinc-400"
+            }`}
+          >
+            {cat}
+          </button>
+        ))}
+      </div>
+
+      {/* Opening list */}
+      <div className="flex-1 overflow-y-auto min-h-0 space-y-1">
+        {filtered.map((opening) => (
+          <button
+            key={`${opening.eco}-${opening.name}`}
+            onClick={() => handleSelectOpening(opening)}
+            className="w-full text-left px-3 py-2 rounded-lg bg-zinc-900 hover:bg-zinc-700 border border-zinc-700 hover:border-zinc-500 transition-colors group"
+          >
+            <div className="flex items-center justify-between">
+              <span className="font-medium text-sm text-white group-hover:text-blue-300 transition-colors">
+                {opening.name}
+              </span>
+              <span className="text-xs font-mono text-zinc-500">{opening.eco}</span>
+            </div>
+            <div className="text-xs text-zinc-500 mt-0.5">{opening.category}</div>
+          </button>
+        ))}
+        {filtered.length === 0 && (
+          <p className="text-zinc-500 text-sm text-center mt-4">No openings found</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default OpeningsPanel;

--- a/src/data/openings.ts
+++ b/src/data/openings.ts
@@ -1,0 +1,283 @@
+export interface Opening {
+  eco: string;
+  name: string;
+  /** Moves in UCI format */
+  moves: string[];
+  description: string;
+  category: "e4 Openings" | "d4 Openings" | "Flank Openings";
+}
+
+export const OPENINGS: Opening[] = [
+  // ── e4 Openings ─────────────────────────────────────────────────
+  {
+    eco: "C50",
+    name: "Italian Game",
+    moves: ["e2e4", "e7e5", "g1f3", "b8c6", "f1c4"],
+    description:
+      "One of the oldest openings, aiming to control the center and quickly develop pieces to attack the f7 pawn. White builds a classical center and develops naturally.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "C51",
+    name: "Evans Gambit",
+    moves: ["e2e4", "e7e5", "g1f3", "b8c6", "f1c4", "f8c5", "b2b4"],
+    description:
+      "An aggressive offshoot of the Italian Game. White sacrifices the b-pawn to gain a strong center and attacking chances. Loved by Kasparov for its sharp, tactical play.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "C60",
+    name: "Ruy Lopez (Spanish)",
+    moves: ["e2e4", "e7e5", "g1f3", "b8c6", "f1b5"],
+    description:
+      "One of the most respected openings in chess. White pins the knight to pressure e5 and eventually look for the bishop pair advantage. Leads to rich strategic battles.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "C67",
+    name: "Berlin Defense",
+    moves: ["e2e4", "e7e5", "g1f3", "b8c6", "f1b5", "g8f6", "e1g1", "f6e4", "d1e2"],
+    description:
+      "The Berlin is an extremely solid defense against the Ruy Lopez, leading to endgames that black can hold. Popularized by Vladimir Kramnik who used it to defeat Kasparov in 2000.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "B20",
+    name: "Sicilian Defense",
+    moves: ["e2e4", "c7c5"],
+    description:
+      "The most popular response to 1.e4. Black fights for the center asymmetrically and aims for a complex, unbalanced game where both sides have chances. Extremely rich and varied.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "B23",
+    name: "Sicilian: Grand Prix Attack",
+    moves: ["e2e4", "c7c5", "b1c3", "b8c6", "f2f4"],
+    description:
+      "White builds a powerful kingside attack with f4, aiming to overwhelm Black before the Sicilian's counterplay kicks in. Popular at club level for its attacking nature.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "B60",
+    name: "Sicilian: Najdorf",
+    moves: ["e2e4", "c7c5", "g1f3", "d7d6", "d2d4", "c5d4", "f3d4", "g8f6", "b1c3", "a7a6"],
+    description:
+      "The most ambitious Sicilian system, popularized by Miguel Najdorf and played by Fischer, Kasparov, and Carlsen. Black prepares queenside counterplay while keeping options open.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "B70",
+    name: "Sicilian: Dragon",
+    moves: ["e2e4", "c7c5", "g1f3", "d7d6", "d2d4", "c5d4", "f3d4", "g8f6", "b1c3", "g7g6"],
+    description:
+      "Black fianchettos the bishop on g7 creating a powerful diagonal. The Yugoslav Attack (Bc4, f3, Be3) leads to sharp battles where both sides race on opposite wings.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "C00",
+    name: "French Defense",
+    moves: ["e2e4", "e7e6"],
+    description:
+      "A solid, strategic defense. Black allows White a space advantage in exchange for a very solid position. Black typically counterattacks in the center with ...d5 and ...c5.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "C11",
+    name: "French: Classical",
+    moves: ["e2e4", "e7e6", "d2d4", "d7d5", "b1c3", "g8f6"],
+    description:
+      "Black develops the knight to f6 to pressure the e4 pawn. This leads to rich strategic battles around the locked center with White's space advantage balanced by Black's solid structure.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "B10",
+    name: "Caro-Kann Defense",
+    moves: ["e2e4", "c7c6"],
+    description:
+      "A solid, principled defense that avoids the doubled pawn weakness of the French. Black prepares ...d5 with c6 and aims for a good endgame thanks to the unobstructed light-square bishop.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "B12",
+    name: "Caro-Kann: Advance",
+    moves: ["e2e4", "c7c6", "d2d4", "d7d5", "e4e5"],
+    description:
+      "White gains space in the center with e5. Black typically counterattacks with ...c5 and ...Bf5. Leads to strategic positions with clear plans for both sides.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "B01",
+    name: "Scandinavian Defense",
+    moves: ["e2e4", "d7d5"],
+    description:
+      "Black immediately challenges White's center. After exd5, ...Qxd5 or ...Nf6 follows. A reliable opening where Black gets quick development at the cost of tempo.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "C30",
+    name: "King's Gambit",
+    moves: ["e2e4", "e7e5", "f2f4"],
+    description:
+      "One of the oldest and most romantic gambits. White sacrifices the f-pawn to open the f-file and build a massive center. Leads to sharp, unbalanced positions loved by attacking players.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "C33",
+    name: "King's Gambit Accepted",
+    moves: ["e2e4", "e7e5", "f2f4", "e5f4", "f1c4"],
+    description:
+      "Black accepts the gambit pawn. White develops with Bc4 aiming for a powerful attack. This leads to the sharp positions Morphy and Fischer loved to play.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "C40",
+    name: "Petroff Defense",
+    moves: ["e2e4", "e7e5", "g1f3", "g8f6"],
+    description:
+      "Ultra-solid but sometimes considered drawish at the top level. Black mirrors White's development and aims for symmetrical positions. Favorite of players who want a safe, equal game.",
+    category: "e4 Openings",
+  },
+  {
+    eco: "B07",
+    name: "Pirc Defense",
+    moves: ["e2e4", "d7d6", "d2d4", "g8f6", "b1c3", "g7g6"],
+    description:
+      "A hypermodern defense where Black allows White to build a large center then attacks it from the flanks. The fianchettoed bishop on g7 is Black's main weapon.",
+    category: "e4 Openings",
+  },
+
+  // ── d4 Openings ─────────────────────────────────────────────────
+  {
+    eco: "D30",
+    name: "Queen's Gambit Declined",
+    moves: ["d2d4", "d7d5", "c2c4", "e7e6"],
+    description:
+      "Black declines the gambit pawn and maintains a solid pawn structure. One of the most classical openings, leading to rich strategic battles. The backbone of classical opening theory.",
+    category: "d4 Openings",
+  },
+  {
+    eco: "D20",
+    name: "Queen's Gambit Accepted",
+    moves: ["d2d4", "d7d5", "c2c4", "d5c4"],
+    description:
+      "Black accepts the pawn and must deal with White's pressure. By capturing, Black gives up the center temporarily but gets free development. Can transpose into sharp or solid lines.",
+    category: "d4 Openings",
+  },
+  {
+    eco: "D37",
+    name: "QGD: Vienna Variation",
+    moves: ["d2d4", "d7d5", "c2c4", "e7e6", "b1c3", "g8f6", "g1f3", "d5c4"],
+    description:
+      "Black takes the gambit pawn on move 4, hoping to keep it. White gets active piece play in compensation. A modern, ambitious way to play the QGD.",
+    category: "d4 Openings",
+  },
+  {
+    eco: "E60",
+    name: "King's Indian Defense",
+    moves: ["d2d4", "g8f6", "c2c4", "g7g6", "b1c3", "f8g7", "e2e4", "d7d6", "g1f3", "e8g8"],
+    description:
+      "A hyper-modern defense where Black allows White to build a large center then launches a fierce kingside attack. Favorites of Fischer, Kasparov, and many attacking players.",
+    category: "d4 Openings",
+  },
+  {
+    eco: "E20",
+    name: "Nimzo-Indian Defense",
+    moves: ["d2d4", "g8f6", "c2c4", "e7e6", "b1c3", "f8b4"],
+    description:
+      "Black pins the knight and pressures e4, preventing White from establishing a free pawn center. A strategically rich opening characterized by a fight for the dark squares.",
+    category: "d4 Openings",
+  },
+  {
+    eco: "E15",
+    name: "Queen's Indian Defense",
+    moves: ["d2d4", "g8f6", "c2c4", "e7e6", "g1f3", "b7b6"],
+    description:
+      "Black fianchettos on the queenside to control e4. A solid, hypermodern approach that avoids the Nimzo by not playing ...Bb4. Leads to subtle strategic battles.",
+    category: "d4 Openings",
+  },
+  {
+    eco: "D70",
+    name: "Grünfeld Defense",
+    moves: ["d2d4", "g8f6", "c2c4", "g7g6", "b1c3", "d7d5"],
+    description:
+      "Black allows White to build a large center then attacks it with pieces. White gets the powerful center pawn mass; Black targets it with ...c5, ...Bg7, and counterplay. Loved by Fischer and Kasparov.",
+    category: "d4 Openings",
+  },
+  {
+    eco: "D10",
+    name: "Slav Defense",
+    moves: ["d2d4", "d7d5", "c2c4", "c7c6"],
+    description:
+      "A solid defense that supports d5 without blocking the light-squared bishop. One of the most reliable defenses against the Queen's Gambit, favored at all levels.",
+    category: "d4 Openings",
+  },
+  {
+    eco: "D43",
+    name: "Semi-Slav Defense",
+    moves: ["d2d4", "d7d5", "c2c4", "c7c6", "b1c3", "g8f6", "g1f3", "e7e6"],
+    description:
+      "Black combines the Slav and QGD setups. Leads to extremely sharp positions in the Botvinnik and Moscow variations. One of the most deeply analyzed openings in chess.",
+    category: "d4 Openings",
+  },
+  {
+    eco: "A80",
+    name: "Dutch Defense",
+    moves: ["d2d4", "f7f5"],
+    description:
+      "Black fights for e4 at the cost of slightly weakening the kingside. Leads to three main systems: Classical (Stonewall), Leningrad (fianchetto), and Classical. Popular with attacking players.",
+    category: "d4 Openings",
+  },
+
+  // ── Flank Openings ──────────────────────────────────────────────
+  {
+    eco: "A10",
+    name: "English Opening",
+    moves: ["c2c4"],
+    description:
+      "White controls d5 from the flank and delays committing the center pawns. Often transposes into 1.d4 structures. A flexible, solid choice favored by Karpov and Carlsen.",
+    category: "Flank Openings",
+  },
+  {
+    eco: "A20",
+    name: "English: King's English",
+    moves: ["c2c4", "e7e5"],
+    description:
+      "Black grabs the center immediately. White typically responds with Nc3 and g3, building a kingside fianchetto setup. Leads to rich positional battles on both wings.",
+    category: "Flank Openings",
+  },
+  {
+    eco: "A04",
+    name: "Réti Opening",
+    moves: ["g1f3"],
+    description:
+      "A hypermodern approach: White develops the knight and fianchettos to control the center from a distance. Highly flexible and can transpose into many different structures.",
+    category: "Flank Openings",
+  },
+  {
+    eco: "A07",
+    name: "King's Indian Attack",
+    moves: ["g1f3", "d7d5", "g2g3", "g8f6", "f1g2", "e7e6", "e1g1"],
+    description:
+      "White adopts the King's Indian setup as White: Nf3, g3, Bg2, castled. A flexible system that can be used against many Black setups. Fischer used it with great success against the French and Sicilian.",
+    category: "Flank Openings",
+  },
+  {
+    eco: "A00",
+    name: "Bird's Opening",
+    moves: ["f2f4"],
+    description:
+      "White advances the f-pawn to control e5 from the start. Leads to the From's Gambit (1...e5) or other unusual positions. A fighting choice that avoids the main lines.",
+    category: "Flank Openings",
+  },
+  {
+    eco: "A00",
+    name: "Larsen's Opening",
+    moves: ["b2b3"],
+    description:
+      "Bent Larsen's favorite: White prepares to fianchetto the queen's bishop on b2, where it controls the long diagonal. Highly creative and unpredictable, ideal for players who like original positions.",
+    category: "Flank Openings",
+  },
+];
+
+export const CATEGORIES = ["e4 Openings", "d4 Openings", "Flank Openings"] as const;
+export type Category = typeof CATEGORIES[number];

--- a/src/features/ChessPanel.tsx
+++ b/src/features/ChessPanel.tsx
@@ -1,5 +1,8 @@
-import React from "react";
+import React, { useState, useCallback, useMemo } from "react";
+import { Chess } from "chess.js";
 import ChessBoard from "../components/ChessBoard";
+import EvalBar from "../components/EvalBar";
+import CapturedPieces from "../components/CapturedPieces";
 import type { Arrow } from "react-chessboard/dist/chessboard/types";
 
 interface ChessPanelProps {
@@ -15,6 +18,33 @@ interface ChessPanelProps {
   inCheck: boolean;
   kingInCheckSquare: string | null;
   engineArrow: Arrow | null;
+  /** Centipawn evaluation from engine */
+  evalScore: number | null;
+  /** Forced mate (positive = white wins) */
+  mateIn: number | null;
+  /** Whether the engine is currently thinking */
+  engineThinking: boolean;
+  /** Principal variation – UCI move strings */
+  pvLine: string[];
+}
+
+/** Convert up to `maxMoves` UCI moves from `fen` into SAN notation. */
+function pvToSan(fen: string, pvMoves: string[], maxMoves = 8): string[] {
+  const chess = new Chess(fen);
+  const san: string[] = [];
+  for (const uci of pvMoves.slice(0, maxMoves)) {
+    try {
+      const result = chess.move({
+        from: uci.slice(0, 2),
+        to: uci.slice(2, 4),
+        promotion: uci[4] ?? "q",
+      });
+      if (result) san.push(result.san);
+    } catch {
+      break;
+    }
+  }
+  return san;
 }
 
 const ChessPanel: React.FC<ChessPanelProps> = ({
@@ -30,22 +60,207 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
   inCheck,
   kingInCheckSquare,
   engineArrow,
+  evalScore,
+  mateIn,
+  engineThinking,
+  pvLine,
 }) => {
+  const [showBestLine, setShowBestLine] = useState(false);
+  // Preview: step through PV on the board without affecting game history
+  const [pvStep, setPvStep] = useState<number>(-1); // -1 = not previewing
+  const isPreviewing = pvStep >= 0;
+
+  // SAN version of the PV for display
+  const pvSan = useMemo(
+    () => (pvLine.length > 0 ? pvToSan(position, pvLine) : []),
+    [position, pvLine]
+  );
+
+  // Board position when previewing PV
+  const previewFen = useMemo(() => {
+    if (!isPreviewing || pvLine.length === 0) return null;
+    const chess = new Chess(position);
+    for (let i = 0; i <= pvStep && i < pvLine.length; i++) {
+      const uci = pvLine[i];
+      try {
+        chess.move({ from: uci.slice(0, 2), to: uci.slice(2, 4), promotion: uci[4] ?? "q" });
+      } catch {
+        break;
+      }
+    }
+    return chess.fen();
+  }, [position, pvLine, pvStep, isPreviewing]);
+
+  // The last move arrow while previewing
+  const previewLastMove = useMemo(() => {
+    if (!isPreviewing || pvStep < 0) return null;
+    const uci = pvLine[pvStep];
+    if (!uci || uci.length < 4) return null;
+    return { from: uci.slice(0, 2), to: uci.slice(2, 4) };
+  }, [isPreviewing, pvStep, pvLine]);
+
+  const handleToggleBestLine = () => {
+    if (showBestLine) {
+      setShowBestLine(false);
+      setPvStep(-1);
+    } else {
+      setShowBestLine(true);
+    }
+  };
+
+  const handleExitPreview = useCallback(() => {
+    setPvStep(-1);
+  }, []);
+
+  const handlePvStep = useCallback(
+    (dir: 1 | -1) => {
+      setPvStep((s) => {
+        const next = s + dir;
+        if (next < 0) return -1;
+        if (next >= pvLine.length) return s;
+        return next;
+      });
+    },
+    [pvLine.length]
+  );
+
+  const hasPv = pvSan.length > 0;
+
+  // Move labels with numbers like real chess notation: "1. e4  e5  2. Nf3"
+  const pvFormatted = useMemo(() => {
+    const chess = new Chess();
+    let moveNum = chess.moveNumber();
+    let isWhiteTurn = chess.turn() === "w";
+
+    // Determine starting move number from position
+    const pos = new Chess(position);
+    moveNum = pos.moveNumber();
+    isWhiteTurn = pos.turn() === "w";
+
+    return pvSan.map((san, i) => {
+      const num = moveNum + Math.floor((i + (isWhiteTurn ? 0 : 1)) / 2);
+      const isWhite = isWhiteTurn ? i % 2 === 0 : i % 2 === 1;
+      return { san, num, isWhite, idx: i };
+    });
+  }, [pvSan, position]);
+
   return (
-      <div className="border-4 border-zinc-600 rounded-xl p-4 shadow-xl bg-zinc-800 w-full max-w-[615px]">
-      <ChessBoard
-        position={position}
-        onMove={onMove}
-        lastMove={lastMove}
-        inCheck={inCheck}
-        kingInCheckSquare={kingInCheckSquare}
-        engineArrow={engineArrow}
-      />
-      <div className="flex justify-between mt-4 gap-2">
-        <button onClick={onBack} className="btn">← Back</button>
-        <button onClick={onForward} disabled={disableForward} className="btn disabled:opacity-50">→ Forward</button>
-        <button onClick={onUndo} className="btn">Undo</button>
-        <button onClick={onAsk} className="btn bg-blue-600 hover:bg-blue-700">
+    <div className="border-4 border-zinc-600 rounded-xl p-3 shadow-xl bg-zinc-800 w-full">
+      {/* Board + eval bar row */}
+      <div className="flex gap-2 items-stretch">
+        {/* Eval bar (desktop – vertical) */}
+        <div className="hidden md:flex items-stretch">
+          <EvalBar evalScore={evalScore} mateIn={mateIn} thinking={engineThinking} />
+        </div>
+
+        {/* Board column */}
+        <div className="flex-1 flex flex-col min-w-0">
+          {/* Captured pieces – Black's lost pieces (shown above board) */}
+          <CapturedPieces fen={position} side="top" />
+
+          <ChessBoard
+            position={isPreviewing && previewFen ? previewFen : position}
+            onMove={isPreviewing ? () => false : onMove}
+            lastMove={isPreviewing ? previewLastMove : lastMove}
+            inCheck={inCheck}
+            kingInCheckSquare={kingInCheckSquare}
+            engineArrow={isPreviewing ? null : engineArrow}
+          />
+
+          {/* Captured pieces – White's lost pieces (shown below board) */}
+          <CapturedPieces fen={position} side="bottom" />
+        </div>
+      </div>
+
+      {/* Eval bar (mobile – horizontal) */}
+      <div className="md:hidden mt-2 px-1">
+        <EvalBar evalScore={evalScore} mateIn={mateIn} thinking={engineThinking} />
+      </div>
+
+      {/* Best Line Panel */}
+      {showBestLine && (
+        <div className="mt-3 p-3 bg-zinc-900 rounded-lg border border-zinc-700">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-semibold text-zinc-300 uppercase tracking-wide">
+              Engine Best Line
+            </span>
+            <button
+              onClick={() => { setShowBestLine(false); setPvStep(-1); }}
+              className="text-zinc-500 hover:text-white text-xs"
+            >
+              ✕
+            </button>
+          </div>
+
+          {hasPv ? (
+            <>
+              {/* Move tokens */}
+              <div className="flex flex-wrap gap-x-2 gap-y-1 text-sm font-mono mb-3">
+                {pvFormatted.map(({ san, num, isWhite, idx }) => (
+                  <React.Fragment key={idx}>
+                    {isWhite && (
+                      <span className="text-zinc-600">{num}.</span>
+                    )}
+                    <button
+                      onClick={() => setPvStep(idx)}
+                      className={`rounded px-1 transition-colors ${
+                        pvStep === idx
+                          ? "bg-blue-600 text-white"
+                          : "text-zinc-200 hover:bg-zinc-700"
+                      }`}
+                    >
+                      {san}
+                    </button>
+                  </React.Fragment>
+                ))}
+              </div>
+
+              {/* Step controls */}
+              {isPreviewing ? (
+                <div className="flex gap-2 items-center flex-wrap">
+                  <button className="btn text-xs" onClick={() => handlePvStep(-1)} disabled={pvStep <= 0}>
+                    ← Prev
+                  </button>
+                  <button className="btn text-xs" onClick={() => handlePvStep(1)} disabled={pvStep >= pvLine.length - 1}>
+                    Next →
+                  </button>
+                  <button className="btn text-xs bg-red-800 hover:bg-red-700" onClick={handleExitPreview}>
+                    Back to Game
+                  </button>
+                  <span className="text-xs text-zinc-500">
+                    Move {pvStep + 1}/{pvLine.length}
+                  </span>
+                </div>
+              ) : (
+                <button
+                  className="btn text-xs bg-green-800 hover:bg-green-700"
+                  onClick={() => setPvStep(0)}
+                >
+                  ▶ Step Through
+                </button>
+              )}
+            </>
+          ) : (
+            <p className="text-zinc-500 text-xs">
+              {engineThinking ? "Analysing…" : "No line available yet."}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Control buttons */}
+      <div className="flex flex-wrap justify-between mt-3 gap-2">
+        <button onClick={onBack} className="btn text-sm">← Back</button>
+        <button onClick={onForward} disabled={disableForward} className="btn text-sm disabled:opacity-50">→ Forward</button>
+        <button onClick={onUndo} className="btn text-sm">Undo</button>
+        <button
+          onClick={handleToggleBestLine}
+          className={`btn text-sm ${showBestLine ? "bg-amber-700 hover:bg-amber-600" : "bg-zinc-600 hover:bg-zinc-500"}`}
+          title="Show engine's best continuation"
+        >
+          {showBestLine ? "Hide Line" : "Best Line"}
+        </button>
+        <button onClick={onAsk} className="btn text-sm bg-blue-600 hover:bg-blue-700">
           Ask {selectedGM}
         </button>
       </div>

--- a/src/hooks/useStockfish.ts
+++ b/src/hooks/useStockfish.ts
@@ -1,109 +1,176 @@
 import { useEffect, useRef, useCallback, useState } from "react";
 
+export type EvalResult = {
+  bestMove: string | null;
+  /** Centipawns from white's perspective, or ±9999 for forced mate. Null if unknown. */
+  evalScore: number | null;
+  /** "M3" / "M-3" etc when a forced mate is found, otherwise null. */
+  mateIn: number | null;
+  /** Full PV line as UCI moves (e.g. ["e2e4", "e7e5", ...]). */
+  pvLine: string[];
+};
+
 /**
- * Fallback: Lichess cloud evaluation API.
- * Free, no API key needed. Returns the best move for a given FEN.
+ * Lichess cloud evaluation API.
+ * Free, no API key. Returns best move, eval, and PV.
  * https://lichess.org/api#tag/Analysis/operation/apiCloudEval
  */
-async function fetchLichessEval(fen: string): Promise<string | null> {
+async function fetchLichessEval(fen: string): Promise<EvalResult> {
+  const empty: EvalResult = { bestMove: null, evalScore: null, mateIn: null, pvLine: [] };
   try {
     const encoded = encodeURIComponent(fen);
     const res = await fetch(
-      `https://lichess.org/api/cloud-eval?fen=${encoded}&multiPv=1`,
+      `https://lichess.org/api/cloud-eval?fen=${encoded}&multiPv=1`
     );
-    if (!res.ok) return null;
+    if (!res.ok) return empty;
     const data = await res.json();
-    if (data.pvs && data.pvs.length > 0 && data.pvs[0].moves) {
-      // Lichess returns moves in UCI format, space-separated. First is best.
-      return data.pvs[0].moves.split(" ")[0];
+    if (!data.pvs || data.pvs.length === 0) return empty;
+
+    const pv = data.pvs[0];
+    const pvLine: string[] = pv.moves ? pv.moves.split(" ") : [];
+    const bestMove = pvLine[0] ?? null;
+
+    let evalScore: number | null = null;
+    let mateIn: number | null = null;
+
+    if (pv.cp !== undefined) {
+      evalScore = pv.cp;
+    } else if (pv.mate !== undefined) {
+      mateIn = pv.mate;
+      evalScore = pv.mate > 0 ? 9999 : -9999;
     }
-    return null;
+
+    return { bestMove, evalScore, mateIn, pvLine };
   } catch {
-    return null;
+    return empty;
   }
 }
 
+/**
+ * Parse a Stockfish WASM "info" line for score and PV.
+ * Example: "info depth 20 ... score cp 35 ... pv e2e4 e7e5 g1f3"
+ */
+function parseInfoLine(msg: string): { score: number | null; mate: number | null; pv: string[] } {
+  let score: number | null = null;
+  let mate: number | null = null;
+
+  const cpMatch = msg.match(/score cp (-?\d+)/);
+  const mateMatch = msg.match(/score mate (-?\d+)/);
+
+  if (cpMatch) score = parseInt(cpMatch[1], 10);
+  else if (mateMatch) {
+    mate = parseInt(mateMatch[1], 10);
+    score = mate > 0 ? 9999 : -9999;
+  }
+
+  const pvMatch = msg.match(/ pv (.+?)(?:\s+(?:bm|multipv|string|currmove)\b|$)/);
+  const pv = pvMatch ? pvMatch[1].trim().split(/\s+/) : [];
+
+  return { score, mate, pv };
+}
+
 export function useStockfish() {
-  const stockfishRef = useRef<any>(null);
+  const stockfishRef = useRef<{ postMessage: (msg: string) => void; terminate?: () => void } | null>(null);
   const [bestMove, setBestMove] = useState<string | null>(null);
+  const [evalScore, setEvalScore] = useState<number | null>(null);
+  const [mateIn, setMateIn] = useState<number | null>(null);
+  const [pvLine, setPvLine] = useState<string[]>([]);
   const [thinking, setThinking] = useState(false);
   const [usingFallback, setUsingFallback] = useState(false);
   const wasmFailed = useRef(false);
+
+  // Accumulate the best info line seen during WASM analysis
+  const bestInfoRef = useRef<{ score: number | null; mate: number | null; pv: string[] }>({
+    score: null,
+    mate: null,
+    pv: [],
+  });
 
   useEffect(() => {
     if (wasmFailed.current) return;
 
     try {
-      // Dynamic import to avoid build-time issues with WASM
       import("stockfish")
         .then((mod) => {
           try {
             const sf = mod.default();
-            sf.onmessage = (event: any) => {
-              const msg =
-                typeof event === "string" ? event : event?.data ?? "";
-              if (typeof msg === "string" && msg.startsWith("bestmove")) {
+            sf.onmessage = (event: string | { data: string }) => {
+              const msg: string =
+                typeof event === "string" ? event : (event?.data ?? "");
+
+              if (typeof msg !== "string") return;
+
+              // Collect best analysis from info lines (track last best-depth info)
+              if (msg.startsWith("info") && msg.includes("score")) {
+                const parsed = parseInfoLine(msg);
+                // Only update if we got a score (avoids resetting on lowerbound lines)
+                if (parsed.score !== null || parsed.mate !== null) {
+                  bestInfoRef.current = parsed;
+                }
+              }
+
+              if (msg.startsWith("bestmove")) {
                 const move = msg.split(" ")[1];
-                setBestMove(move);
+                const info = bestInfoRef.current;
+                setBestMove(move === "(none)" ? null : (move ?? null));
+                setEvalScore(info.score);
+                setMateIn(info.mate);
+                setPvLine(info.pv.length > 0 ? info.pv : move ? [move] : []);
                 setThinking(false);
               }
             };
             stockfishRef.current = sf;
             sf.postMessage("uci");
           } catch {
-            console.warn(
-              "Stockfish WASM init failed — will use Lichess fallback",
-            );
+            console.warn("Stockfish WASM init failed — will use Lichess fallback");
             wasmFailed.current = true;
             setUsingFallback(true);
           }
         })
         .catch(() => {
-          console.warn(
-            "Stockfish WASM import failed — will use Lichess fallback",
-          );
+          console.warn("Stockfish WASM import failed — will use Lichess fallback");
           wasmFailed.current = true;
           setUsingFallback(true);
         });
     } catch {
-      console.warn(
-        "Stockfish WASM not available — will use Lichess fallback",
-      );
+      console.warn("Stockfish WASM not available — will use Lichess fallback");
       wasmFailed.current = true;
       setUsingFallback(true);
     }
 
     return () => {
-      if (
-        stockfishRef.current &&
-        typeof stockfishRef.current.terminate === "function"
-      ) {
+      if (stockfishRef.current && typeof stockfishRef.current.terminate === "function") {
         stockfishRef.current.terminate();
       }
     };
   }, []);
 
-  const analyzePosition = useCallback(
-    async (fen: string, depth = 15) => {
-      setThinking(true);
-      setBestMove(null);
+  const analyzePosition = useCallback(async (fen: string, depth = 18) => {
+    setThinking(true);
+    setBestMove(null);
+    setEvalScore(null);
+    setMateIn(null);
+    setPvLine([]);
+    bestInfoRef.current = { score: null, mate: null, pv: [] };
 
-      // Try local WASM engine first
-      if (stockfishRef.current && !wasmFailed.current) {
-        stockfishRef.current.postMessage("uci");
-        stockfishRef.current.postMessage(`position fen ${fen}`);
-        stockfishRef.current.postMessage(`go depth ${depth}`);
-        return; // Result arrives via onmessage callback
-      }
+    // Try local WASM engine first
+    if (stockfishRef.current && !wasmFailed.current) {
+      stockfishRef.current.postMessage("stop");
+      stockfishRef.current.postMessage("ucinewgame");
+      stockfishRef.current.postMessage(`position fen ${fen}`);
+      stockfishRef.current.postMessage(`go depth ${depth}`);
+      return; // Result arrives via onmessage callback
+    }
 
-      // Fallback to Lichess cloud evaluation
-      setUsingFallback(true);
-      const move = await fetchLichessEval(fen);
-      setBestMove(move);
-      setThinking(false);
-    },
-    [],
-  );
+    // Fallback to Lichess cloud evaluation
+    setUsingFallback(true);
+    const result = await fetchLichessEval(fen);
+    setBestMove(result.bestMove);
+    setEvalScore(result.evalScore);
+    setMateIn(result.mateIn);
+    setPvLine(result.pvLine);
+    setThinking(false);
+  }, []);
 
-  return { bestMove, analyzePosition, thinking, usingFallback };
+  return { bestMove, evalScore, mateIn, pvLine, analyzePosition, thinking, usingFallback };
 }

--- a/src/types/stockfish.d.ts
+++ b/src/types/stockfish.d.ts
@@ -1,4 +1,10 @@
+interface StockfishEngine {
+  postMessage: (msg: string) => void;
+  onmessage: ((event: string | { data: string }) => void) | null;
+  terminate?: () => void;
+}
+
 declare module "stockfish" {
-  const Stockfish: any;
+  const Stockfish: () => StockfishEngine;
   export default Stockfish;
 }


### PR DESCRIPTION
## Summary
This PR adds a comprehensive opening lessons feature to the chess application, allowing users to browse and study chess openings move-by-move with integrated engine analysis and GM chat support.

## Key Changes

### New Components
- **OpeningsPanel** (`src/components/OpeningsPanel.tsx`): Main UI for browsing and studying openings with:
  - Browse mode: Search and filter openings by category (e4, d4, Flank)
  - Lesson mode: Step through moves with clickable move list, prev/next controls, and auto-play animation
  - Real-time position updates sent to the board
  
- **EvalBar** (`src/components/EvalBar.tsx`): Visual evaluation display showing:
  - Vertical bar on desktop, horizontal on mobile
  - Centipawn scores with mate detection
  - Smooth transitions and thinking state indicator

- **CapturedPieces** (`src/components/CapturedPieces.tsx`): Material count display showing:
  - Pieces captured by each side
  - Material advantage calculation
  - Positioned above/below the board

### Data & Hooks
- **openings.ts**: Database of 30+ chess openings with ECO codes, move sequences (UCI format), descriptions, and categories
- **useStockfish.ts**: Enhanced to return:
  - Evaluation scores (centipawns)
  - Forced mate detection
  - Principal variation (PV) line for best continuation
  - Parsing of Stockfish WASM info lines and Lichess API responses

### UI Enhancements
- **ChessPanel**: 
  - Integrated eval bar and captured pieces display
  - Best line preview mode: step through engine's recommended moves without affecting game history
  - Responsive layout with mobile-optimized eval bar
  
- **App.tsx**:
  - Tab system to switch between "game" and "openings" modes
  - Opening lesson state management (active opening, step, FEN)
  - Context-aware chat: enriches questions with opening name/ECO when studying
  - Keyboard navigation support for opening lessons

- **ChatWindow**: Improved styling and layout with better message formatting

### Implementation Details
- Opening moves stored in UCI format, converted to SAN notation for display
- FEN calculation at each step using Chess.js
- Animation system with configurable timing (600ms initial, 800ms per move)
- Seamless integration with existing engine analysis—when studying an opening, the board analyzes the lesson position instead of the game position
- GM greets user with opening context when entering a lesson
- Captured pieces calculated by comparing current board state to starting position

https://claude.ai/code/session_01DFFBJ422bdQTQjrd2Tb3EA