### PR TITLE
fix: remove unused OpeningVariation import to resolve Railway build error

### DIFF
--- a/src/components/OpeningsPanel.tsx
+++ b/src/components/OpeningsPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { Chess } from "chess.js";
-import { OPENINGS, CATEGORIES, type Opening, type OpeningVariation } from "../data/openings";
+import { OPENINGS, CATEGORIES, type Opening } from "../data/openings";
 
 interface OpeningsPanelProps {
   /** Called when the user enters an opening lesson so we can update the board */


### PR DESCRIPTION
Removes the unused `OpeningVariation` type import from OpeningsPanel.tsx.
TypeScript's noUnusedLocals flag was treating this as a build error.

https://claude.ai/code/session_019qCeUgjxFKGgiavjxfahrv