### PR TITLE
feat: move notation panel, board flip, beta key modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import PersonalitySelector from "./components/PersonalitySelector";
 import ChatWindow from "./components/ChatWindow";
 import ChessPanel from "./features/ChessPanel";
 import OpeningsPanel from "./components/OpeningsPanel";
+import BetaKeyModal from "./components/BetaKeyModal";
 import { useStockfish } from "./hooks/useStockfish";
 import type { EngineLineResult } from "./hooks/useStockfish";
 import type { Opening } from "./data/openings";
@@ -50,6 +51,8 @@ function App() {
   const [historyIndex, setHistoryIndex] = useState(0);
   const [currentFen, setCurrentFen] = useState(chessRef.current.fen());
   const [lastMove, setLastMove] = useState<{ from: string; to: string } | null>(null);
+  // SAN move list parallel to history: sanMoves[i] is the move from history[i] → history[i+1]
+  const [sanMoves, setSanMoves] = useState<string[]>([]);
 
   // Opening lesson state
   const [openingsPanelOpen, setOpeningsPanelOpen] = useState(true);
@@ -59,12 +62,12 @@ function App() {
   // UCI moves for the currently active line (main or variation) — kept in sync by OpeningsPanel
   const [openingActiveMoves, setOpeningActiveMoves] = useState<string[]>([]);
 
-  // Beta access key
-  useEffect(() => {
-    if (!localStorage.getItem("betaKey")) {
-      const key = window.prompt("Enter beta access code:");
-      if (key) localStorage.setItem("betaKey", key);
-    }
+  // Beta access key — show modal if not yet stored
+  const [showBetaModal, setShowBetaModal] = useState(() => !localStorage.getItem("betaKey"));
+
+  const handleBetaKeySubmit = useCallback((key: string) => {
+    localStorage.setItem("betaKey", key);
+    setShowBetaModal(false);
   }, []);
 
   const {
@@ -117,7 +120,10 @@ function App() {
     setLastMove({ from, to });
     const fen = chessRef.current.fen();
     const nextHistory = history.slice(0, historyIndex + 1).concat(fen);
+    // Truncate san branch at current index then append new move
+    const nextSanMoves = sanMoves.slice(0, historyIndex).concat(move.san);
     setHistory(nextHistory);
+    setSanMoves(nextSanMoves);
     setHistoryIndex(nextHistory.length - 1);
     setCurrentFen(fen);
     return true;
@@ -132,6 +138,8 @@ function App() {
   }, [history.length, historyIndex, loadFenAt]);
 
   const handleUndo = useCallback(() => handleBack(), [handleBack]);
+
+  const handleNavigate = useCallback((index: number) => loadFenAt(index), [loadFenAt]);
 
   const handleQuestion = async (question: string) => {
     setThinking(true);
@@ -253,6 +261,9 @@ function App() {
       className="min-h-screen md:h-screen flex flex-col overflow-x-hidden md:overflow-hidden"
       style={{ background: "var(--c-bg)", color: "var(--c-text)", fontFamily: "var(--f-sans)" }}
     >
+      {/* ════ Beta key modal ════ */}
+      {showBetaModal && <BetaKeyModal onSubmit={handleBetaKeySubmit} />}
+
       {/* ════ Header ════ */}
       <header
         className="shrink-0"
@@ -364,6 +375,9 @@ function App() {
               mateIn={mateIn}
               engineThinking={stockfishThinking}
               topLines={topLines}
+              sanMoves={sanMoves}
+              historyIndex={historyIndex}
+              onNavigate={handleNavigate}
             />
           </div>
         </div>

--- a/src/components/BetaKeyModal.tsx
+++ b/src/components/BetaKeyModal.tsx
@@ -1,0 +1,91 @@
+import React, { useState, useRef, useEffect } from "react";
+
+interface BetaKeyModalProps {
+  onSubmit: (key: string) => void;
+}
+
+const BetaKeyModal: React.FC<BetaKeyModalProps> = ({ onSubmit }) => {
+  const [value, setValue] = useState("");
+  const [error, setError] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed) {
+      setError(true);
+      return;
+    }
+    onSubmit(trimmed);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: "rgba(0, 0, 0, 0.85)", backdropFilter: "blur(4px)" }}
+    >
+      <div
+        className="panel w-full max-w-sm p-6 flex flex-col gap-5"
+        style={{ boxShadow: "0 24px 64px rgba(0,0,0,0.8)" }}
+      >
+        {/* Header */}
+        <div className="text-center">
+          <h2
+            className="text-2xl mb-1"
+            style={{
+              fontFamily: "var(--f-serif)",
+              fontWeight: 600,
+              color: "var(--c-gold-bright)",
+              letterSpacing: "-0.01em",
+            }}
+          >
+            Ask <em style={{ fontStyle: "italic", color: "var(--c-text)" }}>GM</em>
+          </h2>
+          <p className="text-sm" style={{ color: "var(--c-text-muted)" }}>
+            Enter your beta access code to continue
+          </p>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <input
+            ref={inputRef}
+            type="password"
+            value={value}
+            onChange={(e) => { setValue(e.target.value); setError(false); }}
+            placeholder="Access code"
+            autoComplete="off"
+            className="w-full text-sm px-4 py-3 rounded-lg focus:outline-none transition-colors text-center tracking-widest"
+            style={{
+              background: "var(--c-raised)",
+              border: `1px solid ${error ? "var(--c-gm-bobby)" : "var(--c-border-bright)"}`,
+              color: "var(--c-text)",
+              fontFamily: "var(--f-mono)",
+              letterSpacing: "0.2em",
+            }}
+            onFocus={(e) => {
+              if (!error) e.currentTarget.style.borderColor = "var(--c-gold)";
+            }}
+            onBlur={(e) => {
+              if (!error) e.currentTarget.style.borderColor = "var(--c-border-bright)";
+            }}
+          />
+          {error && (
+            <p className="text-xs text-center" style={{ color: "var(--c-gm-bobby)" }}>
+              Please enter an access code
+            </p>
+          )}
+          <button type="submit" className="btn-primary w-full py-2.5 text-sm">
+            Enter
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default BetaKeyModal;

--- a/src/components/ChessBoard.tsx
+++ b/src/components/ChessBoard.tsx
@@ -17,6 +17,7 @@ interface ChessBoardProps {
   kingInCheckSquare: string | null;
   engineArrow: Arrow | null;
   animationDuration?: number;
+  boardOrientation?: "white" | "black";
 }
 
 const ChessBoard: React.FC<ChessBoardProps> = ({
@@ -27,6 +28,7 @@ const ChessBoard: React.FC<ChessBoardProps> = ({
   kingInCheckSquare,
   engineArrow,
   animationDuration = 200,
+  boardOrientation = "white",
 }) => {
   const [selectedSquare, setSelectedSquare] = useState<Square | null>(null);
   const [legalMoveSquares, setLegalMoveSquares] = useState<string[]>([]);
@@ -183,6 +185,7 @@ const ChessBoard: React.FC<ChessBoardProps> = ({
     >
       <Chessboard
         position={position}
+        boardOrientation={boardOrientation}
         animationDuration={animationDuration}
         areArrowsAllowed={true}
         customArrows={mergedArrows}

--- a/src/components/MoveNotation.tsx
+++ b/src/components/MoveNotation.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useRef } from "react";
+
+interface MoveNotationProps {
+  /** SAN moves from game start. sanMoves[i] transitions history[i] → history[i+1]. */
+  sanMoves: string[];
+  /** Current history index (0 = start position, 1 = after move 1, etc.) */
+  currentIndex: number;
+  onNavigate: (index: number) => void;
+}
+
+interface MovePair {
+  number: number;
+  white: { san: string; index: number } | null;
+  black: { san: string; index: number } | null;
+}
+
+function buildPairs(sanMoves: string[]): MovePair[] {
+  const pairs: MovePair[] = [];
+  for (let i = 0; i < sanMoves.length; i += 2) {
+    pairs.push({
+      number: Math.floor(i / 2) + 1,
+      white: { san: sanMoves[i], index: i + 1 },
+      black: sanMoves[i + 1] !== undefined ? { san: sanMoves[i + 1], index: i + 2 } : null,
+    });
+  }
+  return pairs;
+}
+
+const MoveNotation: React.FC<MoveNotationProps> = ({ sanMoves, currentIndex, onNavigate }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const activeRef = useRef<HTMLButtonElement>(null);
+
+  // Auto-scroll active move into view
+  useEffect(() => {
+    if (activeRef.current && containerRef.current) {
+      activeRef.current.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [currentIndex]);
+
+  if (sanMoves.length === 0) {
+    return (
+      <div
+        className="flex items-center justify-center py-3 text-xs"
+        style={{ color: "var(--c-text-muted)", fontFamily: "var(--f-mono)" }}
+      >
+        No moves yet
+      </div>
+    );
+  }
+
+  const pairs = buildPairs(sanMoves);
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex flex-wrap gap-x-1 gap-y-0.5 overflow-y-auto"
+      style={{ maxHeight: "5rem", scrollbarWidth: "none" }}
+    >
+      {/* Start position button */}
+      <button
+        onClick={() => onNavigate(0)}
+        className="text-xs px-1.5 py-0.5 rounded transition-all duration-100"
+        style={
+          currentIndex === 0
+            ? { background: "var(--c-gold-dim)", color: "var(--c-gold-bright)", border: "1px solid var(--c-gold)" }
+            : { color: "var(--c-text-muted)", border: "1px solid transparent" }
+        }
+      >
+        ⊙
+      </button>
+
+      {pairs.map((pair) => (
+        <React.Fragment key={pair.number}>
+          {/* Move number */}
+          <span
+            className="text-xs self-center tabular-nums select-none"
+            style={{ color: "var(--c-text-muted)", fontFamily: "var(--f-mono)" }}
+          >
+            {pair.number}.
+          </span>
+
+          {/* White move */}
+          {pair.white && (
+            <button
+              ref={currentIndex === pair.white.index ? activeRef : undefined}
+              onClick={() => onNavigate(pair.white!.index)}
+              className="text-xs px-1.5 py-0.5 rounded transition-all duration-100"
+              style={
+                currentIndex === pair.white.index
+                  ? { background: "var(--c-gold-dim)", color: "var(--c-gold-bright)", border: "1px solid var(--c-gold)", fontFamily: "var(--f-mono)" }
+                  : { color: "var(--c-text-soft)", border: "1px solid transparent", fontFamily: "var(--f-mono)" }
+              }
+            >
+              {pair.white.san}
+            </button>
+          )}
+
+          {/* Black move */}
+          {pair.black && (
+            <button
+              ref={currentIndex === pair.black.index ? activeRef : undefined}
+              onClick={() => onNavigate(pair.black!.index)}
+              className="text-xs px-1.5 py-0.5 rounded transition-all duration-100"
+              style={
+                currentIndex === pair.black.index
+                  ? { background: "var(--c-gold-dim)", color: "var(--c-gold-bright)", border: "1px solid var(--c-gold)", fontFamily: "var(--f-mono)" }
+                  : { color: "var(--c-text-soft)", border: "1px solid transparent", fontFamily: "var(--f-mono)" }
+              }
+            >
+              {pair.black.san}
+            </button>
+          )}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};
+
+export default MoveNotation;

--- a/src/features/ChessPanel.tsx
+++ b/src/features/ChessPanel.tsx
@@ -4,6 +4,7 @@ import ChessBoard from "../components/ChessBoard";
 import EvalBar from "../components/EvalBar";
 import CapturedPieces from "../components/CapturedPieces";
 import EngineLines from "../components/EngineLines";
+import MoveNotation from "../components/MoveNotation";
 import type { Arrow } from "react-chessboard/dist/chessboard/types";
 import type { EngineLineResult } from "../hooks/useStockfish";
 
@@ -24,6 +25,9 @@ interface ChessPanelProps {
   mateIn: number | null;
   engineThinking: boolean;
   topLines: EngineLineResult[];
+  sanMoves: string[];
+  historyIndex: number;
+  onNavigate: (index: number) => void;
 }
 
 const ChessPanel: React.FC<ChessPanelProps> = ({
@@ -43,7 +47,11 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
   mateIn,
   engineThinking,
   topLines,
+  sanMoves,
+  historyIndex,
+  onNavigate,
 }) => {
+  const [boardFlipped, setBoardFlipped] = useState(false);
   // Which engine line is selected for preview (-1 = none)
   const [selectedLine, setSelectedLine] = useState(-1);
   // Which move within the selected line we're previewing (-1 = not yet stepping)
@@ -134,6 +142,7 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
             kingInCheckSquare={kingInCheckSquare}
             engineArrow={isPreviewing ? null : engineArrow}
             animationDuration={isPreviewing ? 0 : 200}
+            boardOrientation={boardFlipped ? "black" : "white"}
           />
 
           <CapturedPieces fen={position} side="bottom" />
@@ -144,6 +153,20 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
       <div className="md:hidden mt-2 px-1">
         <EvalBar evalScore={evalScore} mateIn={mateIn} thinking={engineThinking} />
       </div>
+
+      {/* ── Move notation ── */}
+      {sanMoves.length > 0 && (
+        <div
+          className="mt-3 pt-3 px-1"
+          style={{ borderTop: "1px solid var(--c-border)" }}
+        >
+          <MoveNotation
+            sanMoves={sanMoves}
+            currentIndex={historyIndex}
+            onNavigate={onNavigate}
+          />
+        </div>
+      )}
 
       {/* ── Engine lines ── */}
       <div className="mt-3">
@@ -165,14 +188,17 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
         style={{ borderTop: "1px solid var(--c-border)" }}
       >
         <button onClick={onBack} className="btn text-sm">← Back</button>
-        <button
-          onClick={onForward}
-          disabled={disableForward}
-          className="btn text-sm"
-        >
+        <button onClick={onForward} disabled={disableForward} className="btn text-sm">
           Forward →
         </button>
         <button onClick={onUndo} className="btn text-sm">Undo</button>
+        <button
+          onClick={() => setBoardFlipped((f) => !f)}
+          className="btn text-sm"
+          title="Flip board"
+        >
+          ⇅
+        </button>
         <button
           onClick={onAsk}
           className="btn text-sm ml-auto"


### PR DESCRIPTION
Move notation panel
- New MoveNotation component: PGN-style game record rendered as clickable move pairs inline below the board; current move highlighted in gold; auto-scrolls to active move; click any move to jump directly to that position
- App.tsx tracks sanMoves[] in parallel with history[] — updated on each move and correctly truncated when branching after going back
- ChessPanel receives sanMoves, historyIndex, onNavigate and renders the panel

Board flip
- Flip button (⇅) added to control row in ChessPanel
- boardFlipped state local to ChessPanel; passes boardOrientation prop to ChessBoard
- ChessBoard accepts and forwards boardOrientation to react-chessboard

Beta key modal
- Replace jarring window.prompt() with a proper BetaKeyModal component
- Matches dark design system; password input with tracking, error state, centered overlay with backdrop blur
- showBetaModal state initialized from localStorage so it only appears once