### PR TITLE
feat: comprehensive UI/UX and AI coaching improvements

### DIFF
--- a/server/gmPersonalities.js
+++ b/server/gmPersonalities.js
@@ -1,87 +1,123 @@
 /**
  * GM Personality definitions for Ask-GM.
  *
- * Each personality shapes the system prompt so that Claude responds
- * in the distinctive voice and chess philosophy of that grandmaster.
+ * Each personality shapes the system prompt so Claude responds
+ * in the distinctive voice, chess philosophy, and speech patterns
+ * of that grandmaster.
  */
 
 const gmPersonalities = {
   Magnus: {
     name: "Magnus Carlsen",
-    systemPrompt: `You are Magnus Carlsen, the Norwegian chess world champion widely considered the greatest player of all time.
+    systemPrompt: `You are Magnus Carlsen, the Norwegian chess prodigy who became World Chess Champion in 2013 and held the title until 2023. You achieved the highest FIDE rating in history (2882) and are universally considered the greatest chess player of all time.
+
+IDENTITY & BACKGROUND:
+- Norwegian, born 1990. Became a grandmaster at age 13.
+- Known for your "universal" style — supremely strong in all phases (opening, middlegame, endgame).
+- Your endgame technique is unparalleled. You've won many games considered objectively drawn by computers.
+- You are also a world champion in rapid and blitz formats — the most versatile player in history.
+- Favorite openings with White: 1.e4, the Ruy Lopez, Catalan, London System, quiet positional setups.
+- Favorite openings with Black: Sicilian (various), Nimzo-Indian, Grünfeld — anything that fights for the center.
 
 PERSONALITY & TONE:
-- Calm, measured, and quietly confident. You speak with understated authority.
-- You are precise with your language — never over-explain when a clear sentence will do.
-- You have dry Scandinavian humor. You occasionally drop subtle, deadpan observations.
-- You prefer elegance and accuracy over flashiness.
-- When analyzing, you focus on positional nuances, long-term plans, and endgame technique.
-- You respect your opponent but make it clear you see deeper into the position than most.
+- Calm, measured, and quietly confident. Your authority comes from precision, not volume.
+- Dry Scandinavian humor. Deadpan observations that catch people off guard.
+- You sometimes seem almost bored by positions others find complicated. You see so many moves ahead it's almost effortless.
+- You are direct and honest — if a move is bad, you'll say so, but without drama.
+- You find beauty in subtlety: a small positional advantage exploited over 50 moves, a rook endgame technique most players would draw.
+- You respect opponents but are not afraid to state your assessment with confidence.
 
 CHESS PHILOSOPHY:
-- You believe in universal chess — mastery of all phases, especially endgames.
-- You value practical chances, grinding advantages, and making life difficult for your opponent.
-- You find beauty in small edges, precise technique, and converting "equal" positions.
-- You often reference the importance of not just finding the best move, but understanding WHY it's best.
+- "Chess is about understanding, not memorization."
+- You value practical chances over theoretical perfection. You make life HARD for your opponent.
+- Converting small advantages through technique is as satisfying to you as a brilliant combination.
+- The endgame is where you shine. You can feel which endings are winning even when engines call them draws.
+- "You have to have a feel for the position. It's not just calculation."
 
 SPEAKING STYLE:
-- Concise but insightful. You don't ramble.
-- You might say things like "This is quite natural," "The position speaks for itself," or "It's not complicated if you understand the structure."
-- When something is bad, you understate it: "This is not ideal" or "I wouldn't be comfortable here."
-- You occasionally reference your own games or classical examples when relevant.`,
+- Concise and precise. You never ramble. One exact sentence is worth more than five vague ones.
+- Natural understatement: "This is quite natural," "The position is a bit unpleasant for Black," "I wouldn't be comfortable here."
+- When something is clearly wrong: "This doesn't really work," "Yeah, that's just bad," "I'm not sure what the idea is there."
+- You occasionally reference your own games or those of classical masters (Karpov, Fischer, Capablanca) when they illustrate a point.
+- You might say things like: "I like the structure here," "The knight is a bit misplaced," "You should keep an eye on the d-file," "This endgame should be holdable."
+- Rare but genuine enthusiasm: "Now THIS is interesting," or "Okay, I actually like that idea."`,
   },
 
   Hikaru: {
     name: "Hikaru Nakamura",
-    systemPrompt: `You are Hikaru Nakamura, the American super-grandmaster, elite speed chess player, and popular chess streamer.
+    systemPrompt: `You are Hikaru Nakamura, the American super-grandmaster, five-time U.S. Chess Champion, and one of the most popular chess streamers in the world. You've been ranked #1 in the world in classical, rapid, and blitz. You're a household name in modern chess culture.
+
+IDENTITY & BACKGROUND:
+- American, born 1987 in Hirakata, Japan. Became a grandmaster at age 15 — second youngest American ever.
+- Known as an elite speed chess player, you've won more online rapid/blitz tournaments than anyone.
+- You have one of the deepest opening preparations in the world — you know theory to incredible depth.
+- Favorite openings with White: 1.e4, King's Indian Attack, Catalan, various aggressive systems.
+- Favorite openings with Black: Sicilian Najdorf, King's Indian Defense, Grünfeld, Benko Gambit.
+- You popularized the "Bongcloud" opening as a form of humor and anti-theory.
+- Famous for your online dominance on Chess.com and Lichess, often beating top engines.
 
 PERSONALITY & TONE:
-- High energy, direct, and fast-paced. You think out loud and react in real-time.
-- You are supremely confident in blitz and rapid. You've seen every trick in the book.
-- You use modern chess internet culture and streaming lingo naturally: "chat," "absolutely crushing," "this is actually insane," "let's go," "gg."
-- You are competitive and sometimes blunt. You don't sugarcoat bad moves.
-- You get excited about tactical fireworks and sharp positions.
+- High energy, reactive, fast-paced. You process positions quickly and your words match your thinking speed.
+- Supremely confident — especially in fast time controls. You've seen every trick, trap, and tactic.
+- You use internet/streaming culture naturally: "chat," "this is insane," "absolutely filthy," "let's go," "no shot," "GG," "pog."
+- You're real and direct. You say what you think without sugarcoating, but you're not mean-spirited.
+- You get genuinely hyped about tactical shots, sacrifices, and sharp complications.
+- You have a healthy ego. You know how good you are and you're not shy about it.
 
 CHESS PHILOSOPHY:
-- You are a tactical genius who thrives in complicated, sharp positions.
-- You believe in speed, pattern recognition, and trusting your instincts.
-- You love traps, gambits, and punishing inaccuracies ruthlessly.
-- You value practical play over theoretical perfection — "winning is winning."
-- You have deep opening preparation but present it casually.
+- Speed and pattern recognition above all. You've seen the position before, even if you haven't consciously studied it.
+- Trust your instincts in fast positions. Calculation is important but tempo matters.
+- Sharp, forcing lines beat slow maneuvering — you want to attack, create complications, punish inaccuracies.
+- Opening preparation is a real weapon. Deep prep can literally win the game in 20 moves.
+- "Winning is winning. It doesn't matter if it's 'clean' — if you win, you win."
 
 SPEAKING STYLE:
-- Casual, stream-of-consciousness. You narrate your thoughts as they happen.
-- You might say things like "Okay so this is actually really interesting," "Chat, this is just winning," "Nah, that doesn't work," or "Let me show you why this is crushing."
-- When something is bad you say it plainly: "Yeah this is just lost," "That's a blunder," "This is pain."
-- You reference engine evaluations naturally and aren't afraid to disagree with them.
-- You sometimes address the user as "chat" as if you're streaming.`,
+- Stream-of-consciousness. You react in real time, like you're thinking out loud at the board.
+- High frequency phrases: "Okay so this is actually really interesting," "Nah that doesn't work," "Chat, this is just winning," "Let me explain why this is crushing," "Yeah this is just lost," "Okay so the move here is…"
+- When something is bad: "That's a blunder," "This is just pain," "There's no way that's good," "Yeah I'm not doing that."
+- You address the user as if they're in your stream — engaged, direct, like you're coaching in real time.
+- You sometimes disagree with the engine and make a case for your line.
+- You get excited: "WAIT — do you see that?!" or "Okay this is actually fire."`,
   },
 
   Bobby: {
     name: "Bobby Fischer",
-    systemPrompt: `You are Bobby Fischer, the legendary American chess world champion, one of the most brilliant and intense chess minds in history.
+    systemPrompt: `You are Bobby Fischer, the 11th World Chess Champion and arguably the most gifted chess mind who ever lived. You destroyed the Soviet chess machine almost single-handedly and won the 1972 World Championship match against Boris Spassky with an iconic performance that captured the entire world's attention.
+
+IDENTITY & BACKGROUND:
+- American, born 1943 in Chicago. Became a grandmaster at age 15 — the youngest in history at the time.
+- You learned chess mostly alone, mastering it through sheer will and obsessive study.
+- Your style: aggressive, perfectly principled, devastatingly precise. You played to WIN — not to draw.
+- Favorite openings with White: ALWAYS 1.e4. The Ruy Lopez, the Sicilian (as White, 3.d4 or Anti-Sicilian systems), the Spanish Game.
+- Favorite openings with Black: The Sicilian Najdorf and Poisoned Pawn variation. The King's Indian Defense. Later, Grünfeld.
+- Famous games: "The Game of the Century" vs. Donald Byrne (1956), "The Brilliancy" vs. Robert Byrne (1964), your legendary 1972 match.
+- You memorized entire opening encyclopedias and studied chess 10-12 hours per day at your peak.
 
 PERSONALITY & TONE:
-- Intense, uncompromising, and supremely self-assured. You are a chess purist.
-- You have an almost supernatural ability to see through to the heart of a position.
-- You speak with conviction and drama. Chess is everything — it's art, war, and truth.
-- You are direct to the point of being blunt. You don't tolerate mediocrity.
-- You have a flair for the dramatic and memorable quote.
+- Intense, uncompromising, supremely self-assured. You have a near-religious belief in your chess abilities.
+- You speak with conviction and absolute certainty. Hedging is not in your vocabulary.
+- You have genuine contempt for weak or passive play. Chess is about imposing YOUR will on the position.
+- You are passionate and dramatic. Chess is art, war, and the ultimate test of the mind — all at once.
+- You can be blunt to the point of rudeness when you see a bad move. You don't tolerate mediocrity.
+- You believe you see the board deeper and more clearly than almost anyone who has ever lived.
 
 CHESS PHILOSOPHY:
-- You believe in aggressive, principled chess. Attack when you can, and attack precisely.
-- You demand perfection from yourself. Every move should have purpose.
-- You believe the opening should be played with precision, the middlegame with imagination, and the endgame with exactness.
-- You despise draws and passive play. Chess is about imposing your will.
-- You believe in deep preparation and knowing your openings inside and out.
+- "Chess is war over the board. The object is to crush the opponent's mind."
+- The opening must be played with precision and purpose. Every pawn, every piece has a reason.
+- Attacks must be relentless. If you can attack, you ATTACK. Passive positions are cowardice.
+- The endgame must be played with absolute exactness — no amateur sloppiness.
+- "There are tough players and nice guys, and I'm a tough player."
+- Draws are almost an insult. You play for the win every single game.
+- You believe in deep study, preparation, and knowing your opponent's weaknesses.
 
 SPEAKING STYLE:
-- Bold, declarative statements. You speak in absolutes.
-- You might say things like "This move is obvious if you truly understand chess," "There's only one move here," or "I see the whole board."
-- When something is bad: "This is a terrible move. Absolutely terrible." or "No serious player would consider this."
-- You reference classical games, your own victories, and great attacking chess.
-- You occasionally make grand pronouncements about chess being the ultimate contest of minds.
-- You don't hedge. You state your assessment with total certainty.`,
+- Bold, declarative, absolute statements. You don't say "maybe" or "perhaps."
+- Strong openings: "There is only one move here," "This is obvious if you understand chess," "Look at this position — it's won."
+- When something is wrong: "This is a terrible move. Absolutely terrible." "No serious player would play this." "I can't believe you considered that."
+- Grand pronouncements: "Chess is the art of analysis," "The beauty of this position is self-evident," "Any master would know this immediately."
+- You reference your own games as examples of correct play. You also cite Morphy, Capablanca, Tal.
+- You speak as if you're explaining something that should be obvious to anyone paying attention.
+- Occasional warmth when something genuinely impresses you: "Now THAT is chess. That's the kind of move I respect."`,
   },
 };
 

--- a/server/index.js
+++ b/server/index.js
@@ -46,7 +46,6 @@ const anthropic = new Anthropic({
 
 /**
  * Format a centipawn score as a human-readable eval string.
- * e.g. 35 → "+0.35", -120 → "-1.20", mate 3 → "#3", mate -2 → "#-2"
  */
 function formatEval(score, mate) {
   if (mate !== null && mate !== undefined) {
@@ -63,7 +62,7 @@ function formatEval(score, mate) {
  * Convert a UCI PV array to SAN notation with move numbers.
  * e.g. ["e2e4", "e7e5", "g1f3"] from starting pos → "1. e4 e5 2. Nf3"
  */
-function formatPvLine(fen, pvMoves, maxMoves = 6) {
+function formatPvLine(fen, pvMoves, maxMoves = 7) {
   const chess = new Chess(fen);
   const startMoveNum = chess.moveNumber();
   const startsWhite = chess.turn() === "w";
@@ -82,7 +81,7 @@ function formatPvLine(fen, pvMoves, maxMoves = 6) {
       const moveNum = startMoveNum + Math.floor((i + (startsWhite ? 0 : 1)) / 2);
 
       if (isWhite) parts.push(`${moveNum}.`);
-      else if (i === 0) parts.push(`${moveNum}...`); // black to move first
+      else if (i === 0) parts.push(`${moveNum}...`);
       parts.push(result.san);
     } catch {
       // Stop on any illegal move
@@ -93,83 +92,191 @@ function formatPvLine(fen, pvMoves, maxMoves = 6) {
 }
 
 /**
- * Build the system prompt combining GM personality with structured chess context.
- *
- * Architecture: Stockfish provides all candidate moves. Claude's role is to explain
- * and coach — never to invent moves from scratch.
+ * Compute a human-readable material balance string from a FEN.
+ * Returns something like "White is up a knight (+3)" or "Material is equal".
  */
-function buildSystemPrompt(selectedGM, currentFen, moveHistory, topLines) {
+function getMaterialBalance(fen) {
+  const PIECE_VALUES = { p: 1, n: 3, b: 3, r: 5, q: 9 };
+  try {
+    const chess = new Chess(fen);
+    let whiteTotal = 0;
+    let blackTotal = 0;
+
+    for (const row of chess.board()) {
+      for (const piece of row) {
+        if (!piece || piece.type === "k") continue;
+        const val = PIECE_VALUES[piece.type] ?? 0;
+        if (piece.color === "w") whiteTotal += val;
+        else blackTotal += val;
+      }
+    }
+
+    const diff = whiteTotal - blackTotal;
+    if (diff === 0) return "Material is equal.";
+    const side = diff > 0 ? "White" : "Black";
+    const abs = Math.abs(diff);
+    if (abs >= 9) return `${side} is up a queen (+${abs} points).`;
+    if (abs >= 5) return `${side} is up a rook (+${abs} points).`;
+    if (abs >= 3) return `${side} is up a minor piece (+${abs} points).`;
+    return `${side} is ahead by ${abs} pawn${abs > 1 ? "s" : ""}.`;
+  } catch {
+    return "Material balance unknown.";
+  }
+}
+
+/**
+ * Describe the position type (open/closed/semi-open) based on pawn structure.
+ */
+function getPositionType(fen) {
+  try {
+    const chess = new Chess(fen);
+    let openFiles = 0;
+    let totalPawns = 0;
+
+    const files = ["a", "b", "c", "d", "e", "f", "g", "h"];
+    for (const file of files) {
+      let hasWhitePawn = false;
+      let hasBlackPawn = false;
+      for (let rank = 1; rank <= 8; rank++) {
+        const piece = chess.get(`${file}${rank}`);
+        if (piece?.type === "p") {
+          totalPawns++;
+          if (piece.color === "w") hasWhitePawn = true;
+          else hasBlackPawn = true;
+        }
+      }
+      if (!hasWhitePawn && !hasBlackPawn) openFiles++;
+    }
+
+    if (totalPawns <= 8) return "endgame (few pawns remaining)";
+    if (openFiles >= 3) return "open (many open files, piece activity is key)";
+    if (openFiles >= 1) return "semi-open (mixed, balance of positional and tactical play)";
+    return "closed (blocked pawn structure, long-term maneuvering)";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Check king safety — is each king still castled or has it moved to the center?
+ */
+function getKingSafety(fen) {
+  try {
+    const chess = new Chess(fen);
+    const notes = [];
+
+    for (const color of ["w", "b"]) {
+      const label = color === "w" ? "White" : "Black";
+      const squares = chess.findPiece({ type: "k", color });
+      if (squares.length === 0) continue;
+      const sq = squares[0];
+      const file = sq[0];
+      const rank = sq[1];
+
+      const isKingsideCastled = (color === "w" && sq === "g1") || (color === "b" && sq === "g8");
+      const isQueensideCastled = (color === "w" && sq === "c1") || (color === "b" && sq === "c8");
+      const isCenter = ["d", "e"].includes(file) && ["3", "4", "5", "6"].includes(rank);
+
+      if (isKingsideCastled) notes.push(`${label}'s king is safely castled kingside.`);
+      else if (isQueensideCastled) notes.push(`${label}'s king is castled queenside.`);
+      else if (isCenter) notes.push(`${label}'s king is in the CENTER — potentially vulnerable.`);
+    }
+
+    return notes.join(" ") || "King safety: both kings appear safe.";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Build the system prompt combining GM personality with structured chess context.
+ */
+function buildSystemPrompt(selectedGM, currentFen, moveHistory, topLines, openingName) {
   const gm = gmPersonalities[selectedGM];
   if (!gm) throw new Error(`Unknown GM personality: ${selectedGM}`);
 
-  // --- Position context ---
-  let chessContext = `\n\nCURRENT POSITION:\n`;
+  const chess = (() => { try { return new Chess(currentFen); } catch { return null; } })();
+  const isGameOver = chess ? (chess.isCheckmate() || chess.isDraw() || chess.isStalemate()) : false;
+  const sideToMove = chess?.turn() === "w" ? "White" : "Black";
+  const moveNum = chess?.moveNumber() ?? 1;
+
+  // ── Chess context section ──
+  let chessContext = `\n\n═══════════════════════════════════
+CURRENT POSITION (Move ${moveNum}, ${sideToMove} to play)
+═══════════════════════════════════\n`;
   chessContext += `FEN: ${currentFen}\n`;
 
+  // Opening recognition
+  if (openingName) {
+    chessContext += `Opening: ${openingName}\n`;
+  }
+
+  // Move history
   if (moveHistory && moveHistory.length > 0) {
     const formatted = moveHistory.reduce((acc, san, i) => {
       if (i % 2 === 0) return acc + `${Math.floor(i / 2) + 1}. ${san} `;
       return acc + `${san} `;
     }, "").trim();
-    chessContext += `Game so far: ${formatted}\n`;
+    chessContext += `Game moves so far: ${formatted}\n`;
   }
 
-  // --- Legal moves (hard constraint reference) ---
-  try {
-    const chess = new Chess(currentFen);
+  // Position context
+  const material = getMaterialBalance(currentFen);
+  const posType = getPositionType(currentFen);
+  const kingSafety = getKingSafety(currentFen);
+
+  chessContext += `\nPOSITION ASSESSMENT:\n`;
+  chessContext += `• ${material}\n`;
+  chessContext += `• Position type: ${posType}\n`;
+  if (kingSafety) chessContext += `• ${kingSafety}\n`;
+  if (isGameOver) chessContext += `• The game is OVER (checkmate, draw, or stalemate).\n`;
+
+  // Legal moves
+  if (chess && !isGameOver) {
     const legalMoves = chess.moves();
-    if (legalMoves.length > 0) {
-      chessContext += `Legal moves: ${legalMoves.join(", ")}\n`;
+    if (legalMoves.length > 0 && legalMoves.length <= 40) {
+      chessContext += `• Legal moves: ${legalMoves.join(", ")}\n`;
     }
-  } catch {
-    // Position may be terminal — no legal moves
   }
 
-  // --- Engine analysis (forced menu) ---
+  // Engine analysis
   if (topLines && topLines.length > 0) {
-    chessContext += `\nENGINE ANALYSIS (Stockfish — top lines):\n`;
-    chessContext += `These are the only moves you are permitted to recommend. Do not suggest any move not listed here.\n`;
+    chessContext += `\nSTOCKFISH ENGINE ANALYSIS (depth 18+):\n`;
+    chessContext += `CRITICAL: You may ONLY recommend moves that appear in these lines. Never suggest any other move.\n`;
 
     topLines.forEach((line, i) => {
       if (!line.pv || line.pv.length === 0) return;
       const evalStr = formatEval(line.score, line.mate);
-      const sanLine = formatPvLine(currentFen, line.pv, 6);
+      const sanLine = formatPvLine(currentFen, line.pv, 7);
       if (sanLine) {
-        chessContext += `Line ${i + 1} (${evalStr}): ${sanLine}\n`;
+        const label = i === 0 ? "BEST" : `Alt ${i}`;
+        chessContext += `[${label}] ${evalStr}: ${sanLine}\n`;
       }
     });
   } else {
-    chessContext += `\nEngine analysis is not yet available for this position.\n`;
-    chessContext += `If asked for a specific move, acknowledge that you are still evaluating and offer positional/strategic guidance only.\n`;
+    chessContext += `\nEngine analysis is loading or unavailable for this position.\n`;
+    chessContext += `If asked for a specific move recommendation, acknowledge the analysis is still loading and offer strategic/conceptual guidance instead.\n`;
   }
 
-  // --- Response instructions ---
-  chessContext += `\nRESPONSE INSTRUCTIONS:\n`;
-  chessContext += `- Respond in character as ${gm.name} at all times.\n`;
-  chessContext += `- You MUST only recommend moves that appear in the engine lines above. Never invent, guess, or suggest any other move.\n`;
-  chessContext += `- Match response length to the question: simple questions ("what should I play?") → 1-2 sentences. Positional or strategic questions → up to 4-5 sentences.\n`;
-  chessContext += `- When citing a move, use the SAN notation from the engine lines (e.g. "Nf3 is the right move here").\n`;
-  chessContext += `- Reference specific squares and pieces to ground your advice in the actual position.\n`;
-  chessContext += `- If asked something unrelated to chess, briefly redirect in character.\n`;
+  // Response instructions
+  chessContext += `\nRESPONSE GUIDELINES:\n`;
+  chessContext += `- Stay fully in character as ${gm.name} at ALL times. Your voice, personality, and chess philosophy must be unmistakable.\n`;
+  chessContext += `- ONLY recommend moves from the engine lines above — never invent or guess moves.\n`;
+  chessContext += `- Scale response length to the question: "Best move?" → 1-2 punchy sentences. Strategic/conceptual questions → 3-5 sentences.\n`;
+  chessContext += `- Use standard SAN notation for moves (e.g., Nf3, Bxe5+, O-O, d4).\n`;
+  chessContext += `- Reference concrete squares, pieces, and structures — ground your advice in THIS position.\n`;
+  chessContext += `- When you explain WHY a move is good, connect it to the position's key features (material, king safety, pawn structure, piece activity).\n`;
+  chessContext += `- If something is off-topic, redirect in character with a brief, sharp comment.\n`;
 
   return gm.systemPrompt + chessContext;
 }
 
 /**
  * POST /api/chat
- *
- * Body: {
- *   selectedGM: string,
- *   currentFen: string,
- *   question: string,
- *   conversationHistory: Array<{ role: string, content: string }>,
- *   moveHistory?: string[],
- *   topLines?: Array<{ pv: string[], score: number | null, mate: number | null }>
- * }
  */
 const chatLimiter = rateLimit({
-  windowMs: 60 * 1000, // 1 minute
-  max: 20,             // max 20 requests per IP per minute
+  windowMs: 60 * 1000,
+  max: 20,
   message: { error: "Too many requests. Please wait a moment before asking again." },
   standardHeaders: true,
   legacyHeaders: false,
@@ -177,13 +284,13 @@ const chatLimiter = rateLimit({
 
 app.post("/api/chat", chatLimiter, async (req, res) => {
   try {
-    const { selectedGM, currentFen, question, conversationHistory, moveHistory, topLines } = req.body;
+    const { selectedGM, currentFen, question, conversationHistory, moveHistory, topLines, openingName } = req.body;
 
     if (!question || !currentFen || !selectedGM) {
       return res.status(400).json({ error: "Missing required fields: question, currentFen, selectedGM" });
     }
 
-    const systemPrompt = buildSystemPrompt(selectedGM, currentFen, moveHistory, topLines);
+    const systemPrompt = buildSystemPrompt(selectedGM, currentFen, moveHistory, topLines, openingName);
 
     const messages = [];
 
@@ -200,7 +307,7 @@ app.post("/api/chat", chatLimiter, async (req, res) => {
 
     const response = await anthropic.messages.create({
       model: "claude-sonnet-4-6",
-      max_tokens: 450,
+      max_tokens: 600,
       system: systemPrompt,
       messages,
     });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import BetaKeyModal from "./components/BetaKeyModal";
 import { useStockfish } from "./hooks/useStockfish";
 import type { EngineLineResult } from "./hooks/useStockfish";
 import type { Opening } from "./data/openings";
+import { detectOpening } from "./utils/openingDetection";
+import type { DetectedOpening } from "./utils/openingDetection";
 
 type ChatMessage = { sender: string; text: string };
 type AppTab = "game" | "openings";
@@ -20,6 +22,7 @@ async function askGM(payload: {
   conversationHistory: { role: string; content: string }[];
   moveHistory?: string[];
   topLines?: EngineLineResult[];
+  openingName?: string;
 }): Promise<string> {
   const res = await fetch("/api/chat", {
     method: "POST",
@@ -51,15 +54,18 @@ function App() {
   const [historyIndex, setHistoryIndex] = useState(0);
   const [currentFen, setCurrentFen] = useState(chessRef.current.fen());
   const [lastMove, setLastMove] = useState<{ from: string; to: string } | null>(null);
-  // SAN move list parallel to history: sanMoves[i] is the move from history[i] → history[i+1]
+  // SAN moves parallel to history: sanMoves[i] is the move from history[i] → history[i+1]
   const [sanMoves, setSanMoves] = useState<string[]>([]);
+  // UCI moves parallel to sanMoves (same indexing)
+  const [uciMoves, setUciMoves] = useState<string[]>([]);
+  // Detected opening from the current game's move sequence
+  const [detectedOpening, setDetectedOpening] = useState<DetectedOpening | null>(null);
 
   // Opening lesson state
   const [openingsPanelOpen, setOpeningsPanelOpen] = useState(true);
   const [activeOpening, setActiveOpening] = useState<Opening | null>(null);
   const [openingStep, setOpeningStep] = useState(-1);
   const [openingFen, setOpeningFen] = useState<string | null>(null);
-  // UCI moves for the currently active line (main or variation) — kept in sync by OpeningsPanel
   const [openingActiveMoves, setOpeningActiveMoves] = useState<string[]>([]);
 
   // Beta access key — show modal if not yet stored
@@ -84,6 +90,13 @@ function App() {
   useEffect(() => {
     analyzePosition(fenToAnalyse);
   }, [fenToAnalyse, analyzePosition]);
+
+  // Update detected opening whenever game UCI moves change
+  useEffect(() => {
+    if (activeTab === "game") {
+      setDetectedOpening(detectOpening(uciMoves.slice(0, historyIndex)));
+    }
+  }, [uciMoves, historyIndex, activeTab]);
 
   const derivedChess = useMemo(() => new Chess(currentFen), [currentFen]);
   const inCheck = derivedChess.inCheck();
@@ -120,10 +133,13 @@ function App() {
     setLastMove({ from, to });
     const fen = chessRef.current.fen();
     const nextHistory = history.slice(0, historyIndex + 1).concat(fen);
-    // Truncate san branch at current index then append new move
+    // Truncate at current index then append new move (handles branching)
     const nextSanMoves = sanMoves.slice(0, historyIndex).concat(move.san);
+    const uciMove = `${from}${to}${promotion ?? ""}`;
+    const nextUciMoves = uciMoves.slice(0, historyIndex).concat(uciMove);
     setHistory(nextHistory);
     setSanMoves(nextSanMoves);
+    setUciMoves(nextUciMoves);
     setHistoryIndex(nextHistory.length - 1);
     setCurrentFen(fen);
     return true;
@@ -153,6 +169,14 @@ function App() {
         : "";
     const enrichedQuestion = openingContext ? openingContext + question : question;
 
+    // Determine the opening name to send to the server
+    const openingNameForServer =
+      activeOpening && activeTab === "openings"
+        ? `${activeOpening.name} (ECO ${activeOpening.eco})`
+        : detectedOpening
+        ? `${detectedOpening.name} (ECO ${detectedOpening.eco})`
+        : undefined;
+
     try {
       const conversationHistory = chatMessages
         .filter((_, i) => i > 0)
@@ -162,8 +186,9 @@ function App() {
           content: msg.text,
         }));
 
-      // In opening lesson mode, derive SAN history from the opening's active moves
-      // (not from chessRef which only tracks the main game board).
+      // Use sanMoves from state (up to current historyIndex) rather than
+      // chessRef.current.history() — that only works after sequential moves,
+      // not after navigating back/forward via loadFenAt.
       let moveHistory: string[];
       if (activeTab === "openings" && openingActiveMoves.length > 0) {
         const chess = new Chess();
@@ -177,7 +202,8 @@ function App() {
           } catch { break; }
         }
       } else {
-        moveHistory = chessRef.current.history();
+        // Use sanMoves[0..historyIndex-1] — accurate regardless of navigation state
+        moveHistory = sanMoves.slice(0, historyIndex);
       }
 
       const response = await askGM({
@@ -187,6 +213,7 @@ function App() {
         conversationHistory,
         moveHistory,
         topLines,
+        openingName: openingNameForServer,
       });
 
       setChatMessages((msgs) => [...msgs, { sender: "GM", text: response }]);
@@ -256,6 +283,12 @@ function App() {
 
   const displayFen = activeTab === "openings" && openingFen ? openingFen : currentFen;
 
+  const gmColor: Record<string, string> = {
+    Magnus: "var(--c-gm-magnus)",
+    Hikaru: "var(--c-gm-hikaru)",
+    Bobby: "var(--c-gm-bobby)",
+  };
+
   return (
     <div
       className="min-h-screen md:h-screen flex flex-col overflow-x-hidden md:overflow-hidden"
@@ -269,20 +302,53 @@ function App() {
         className="shrink-0"
         style={{ background: "var(--c-surface)", borderBottom: "1px solid var(--c-border)" }}
       >
-        {/* ── Main row: Logo + Tabs (+ GM pills on desktop) ── */}
-        <div className="flex items-center justify-between px-4 py-2.5">
+        {/* ── Main row ── */}
+        <div className="flex items-center justify-between px-4 py-2.5 gap-3">
           {/* Brand */}
-          <h1
-            className="text-xl tracking-tight select-none"
-            style={{
-              fontFamily: "var(--f-serif)",
-              fontWeight: 600,
-              color: "var(--c-gold-bright)",
-              letterSpacing: "-0.01em",
-            }}
-          >
-            Ask <em style={{ fontStyle: "italic", color: "var(--c-text)" }}>GM</em>
-          </h1>
+          <div className="flex items-center gap-2 shrink-0">
+            <h1
+              className="text-xl tracking-tight select-none"
+              style={{
+                fontFamily: "var(--f-serif)",
+                fontWeight: 600,
+                color: "var(--c-gold-bright)",
+                letterSpacing: "-0.01em",
+              }}
+            >
+              Ask <em style={{ fontStyle: "italic", color: "var(--c-text)" }}>GM</em>
+            </h1>
+            {/* Opening badge — desktop only */}
+            {activeTab === "game" && detectedOpening && (
+              <span
+                className="hidden md:inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs badge-in"
+                style={{
+                  background: "var(--c-gold-dim)",
+                  border: "1px solid rgba(200,144,64,0.25)",
+                  color: "var(--c-gold)",
+                  fontFamily: "var(--f-mono)",
+                  fontSize: "11px",
+                  maxWidth: "220px",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+                title={`${detectedOpening.name} (${detectedOpening.eco})`}
+              >
+                <span style={{ opacity: 0.6 }}>{detectedOpening.eco}</span>
+                <span
+                  style={{
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    maxWidth: "160px",
+                    display: "inline-block",
+                  }}
+                >
+                  {detectedOpening.name.split(" — ")[0]}
+                </span>
+              </span>
+            )}
+          </div>
 
           <div className="flex items-center gap-2">
             {/* Tab switcher */}
@@ -296,12 +362,13 @@ function App() {
                   <button
                     key={tab}
                     onClick={() => setActiveTab(tab)}
-                    className="px-3 py-1.5 rounded-md font-medium transition-all duration-150 text-xs md:text-sm"
+                    className="px-3 py-1.5 rounded-md font-medium text-xs md:text-sm"
                     style={{
                       background: isActive ? "var(--c-hover)" : "transparent",
                       border: `1px solid ${isActive ? "var(--c-border-bright)" : "transparent"}`,
                       color: isActive ? "var(--c-text)" : "var(--c-text-muted)",
                       fontFamily: "var(--f-sans)",
+                      transition: "background 150ms ease, border-color 150ms ease, color 150ms ease",
                     }}
                   >
                     {tab === "game" ? "♟ Game" : "📖 Openings"}
@@ -310,7 +377,7 @@ function App() {
               })}
             </div>
 
-            {/* GM pills — desktop only (mobile has its own row below) */}
+            {/* GM pills — desktop only */}
             <div className="hidden md:flex">
               <PersonalitySelector selected={selectedGM} onSelect={setSelectedGM} />
             </div>
@@ -318,28 +385,29 @@ function App() {
         </div>
 
         {/* ── Mobile GM selector row ── */}
-        <div
-          className="md:hidden grid grid-cols-3 gap-2 px-3 pb-3"
-        >
+        <div className="md:hidden grid grid-cols-3 gap-2 px-3 pb-3">
           {(["Magnus", "Hikaru", "Bobby"] as const).map((name) => {
-            const color =
-              name === "Magnus" ? "var(--c-gm-magnus)"
-              : name === "Hikaru" ? "var(--c-gm-hikaru)"
-              : "var(--c-gm-bobby)";
+            const color = gmColor[name] ?? "var(--c-gold)";
             const isActive = selectedGM === name;
+            const fullNames: Record<string, string> = {
+              Magnus: "Magnus C.",
+              Hikaru: "Hikaru N.",
+              Bobby: "Bobby F.",
+            };
             return (
               <button
                 key={name}
                 onClick={() => setSelectedGM(name)}
-                className="py-2 rounded-lg text-sm font-medium transition-all duration-150 text-center relative"
+                className="py-2 rounded-lg text-sm font-medium text-center relative"
                 style={{
                   background: isActive ? `${color}18` : "var(--c-raised)",
                   border: `1px solid ${isActive ? color : "var(--c-border-mid)"}`,
                   color: isActive ? color : "var(--c-text-muted)",
                   fontFamily: "var(--f-sans)",
+                  transition: "background 150ms ease, border-color 150ms ease, color 150ms ease",
                 }}
               >
-                {name}
+                {fullNames[name]}
                 {isActive && (
                   <span
                     className="absolute bottom-1 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full"
@@ -350,12 +418,30 @@ function App() {
             );
           })}
         </div>
+
+        {/* ── Mobile opening badge ── */}
+        {activeTab === "game" && detectedOpening && (
+          <div className="md:hidden px-3 pb-2.5">
+            <span
+              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs badge-in"
+              style={{
+                background: "var(--c-gold-dim)",
+                border: "1px solid rgba(200,144,64,0.25)",
+                color: "var(--c-gold)",
+                fontFamily: "var(--f-mono)",
+              }}
+            >
+              <span style={{ opacity: 0.6 }}>{detectedOpening.eco}</span>
+              {detectedOpening.name.split(" — ")[0]}
+            </span>
+          </div>
+        )}
       </header>
 
       {/* ════ Main content ════ */}
       <main className="flex-1 flex flex-col md:flex-row gap-3 p-3 overflow-y-auto md:overflow-hidden md:min-h-0">
 
-        {/* ── Left: Chess board panel — shrinks to board width, doesn't stretch ── */}
+        {/* ── Left: Chess board panel ── */}
         <div className="flex flex-col md:overflow-y-auto md:shrink-0 min-w-0">
           <div className="w-full max-w-[600px]">
             <ChessPanel
@@ -382,7 +468,7 @@ function App() {
           </div>
         </div>
 
-        {/* ── Right: Openings panel + Chat — grows to fill remaining space ── */}
+        {/* ── Right: Openings panel + Chat ── */}
         <div
           className={`flex gap-3 md:flex-1 md:min-w-0 ${
             activeTab === "openings"
@@ -395,7 +481,6 @@ function App() {
             <div
               className={`panel overflow-hidden flex flex-col md:flex-[3] md:min-w-0 md:h-full md:min-h-0 ${openingsPanelOpen ? "min-h-[300px]" : ""}`}
             >
-              {/* Mobile accordion toggle */}
               <button
                 className="md:hidden flex items-center justify-between px-4 py-3 w-full text-left"
                 style={{ borderBottom: "1px solid var(--c-border)" }}
@@ -434,6 +519,7 @@ function App() {
               onSubmit={handleQuestion}
               thinking={thinking}
               selectedGM={selectedGM}
+              detectedOpening={detectedOpening}
             />
           </div>
         </div>

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import type { DetectedOpening } from "../utils/openingDetection";
 
 type Message = { sender: string; text: string };
 
@@ -7,6 +8,7 @@ type ChatWindowProps = {
   onSubmit: (question: string) => void;
   thinking?: boolean;
   selectedGM?: string;
+  detectedOpening?: DetectedOpening | null;
 };
 
 const GM_COLORS: Record<string, string> = {
@@ -15,19 +17,80 @@ const GM_COLORS: Record<string, string> = {
   Bobby:  "var(--c-gm-bobby)",
 };
 
+const GM_FULL_NAMES: Record<string, string> = {
+  Magnus: "Magnus Carlsen",
+  Hikaru: "Hikaru Nakamura",
+  Bobby:  "Bobby Fischer",
+};
+
 const GM_LABELS: Record<string, string> = {
   Magnus: "MC",
   Hikaru: "HN",
   Bobby:  "BF",
 };
 
+const GM_SUBTITLES: Record<string, string> = {
+  Magnus: "World Champion · Highest Elo in History",
+  Hikaru: "Super-GM · Speed Chess Legend",
+  Bobby:  "11th World Champion · The Purist",
+};
+
 const QUICK_ASKS = [
-  "What's the best move?",
-  "What's the plan here?",
+  "Best move?",
+  "Explain the plan",
   "What did I do wrong?",
+  "Why this engine move?",
 ];
 
-const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus" }: ChatWindowProps) => {
+// Chess notation regex — piece moves, castling, captures
+const CHESS_MOVE_RE = /\b(O-O-O|O-O|[KQRBN][a-h]?[1-8]?x?[a-h][1-8](?:=[KQRBN])?[+#]?)\b/g;
+
+function renderChessText(text: string, moveColor: string) {
+  const lines = text.split("\n");
+  return lines.map((line, lineIdx) => {
+    const parts: React.ReactNode[] = [];
+    let lastIndex = 0;
+    CHESS_MOVE_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = CHESS_MOVE_RE.exec(line)) !== null) {
+      if (match.index > lastIndex) {
+        parts.push(line.slice(lastIndex, match.index));
+      }
+      parts.push(
+        <span
+          key={`m-${lineIdx}-${match.index}`}
+          style={{
+            fontFamily: "var(--f-mono)",
+            fontSize: "0.85em",
+            fontWeight: 600,
+            color: moveColor,
+            background: `${moveColor}14`,
+            borderRadius: "3px",
+            padding: "0 3px",
+            letterSpacing: "0.02em",
+          }}
+        >
+          {match[0]}
+        </span>
+      );
+      lastIndex = CHESS_MOVE_RE.lastIndex;
+    }
+
+    if (lastIndex < line.length) {
+      parts.push(line.slice(lastIndex));
+    }
+
+    return (
+      <span key={`line-${lineIdx}`}>
+        {parts}
+        {lineIdx < lines.length - 1 && <br />}
+      </span>
+    );
+  });
+}
+
+const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus", detectedOpening }: ChatWindowProps) => {
   const [input, setInput] = useState("");
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -46,38 +109,51 @@ const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus" }: Cha
 
   const gmColor = GM_COLORS[selectedGM] ?? "var(--c-gold)";
   const gmLabel = GM_LABELS[selectedGM] ?? selectedGM.slice(0, 2).toUpperCase();
+  const gmFullName = GM_FULL_NAMES[selectedGM] ?? selectedGM;
+  const gmSubtitle = GM_SUBTITLES[selectedGM] ?? "";
+
+  const hasOnlyWelcome = messages.length === 1;
 
   return (
-    <div
-      className="panel flex flex-col h-full min-h-0 overflow-hidden"
-    >
+    <div className="panel flex flex-col h-full min-h-0 overflow-hidden">
+
       {/* ── Header ── */}
       <div
-        className="flex items-center gap-2.5 px-4 py-3 shrink-0"
+        className="flex items-center gap-3 px-4 py-3 shrink-0"
         style={{ borderBottom: "1px solid var(--c-border)" }}
       >
-        {/* GM avatar dot */}
+        {/* GM avatar */}
         <span
-          className="inline-flex items-center justify-center w-6 h-6 rounded-full text-xs font-bold shrink-0"
+          className="inline-flex items-center justify-center w-8 h-8 rounded-full shrink-0"
           style={{
-            background: `${gmColor}22`,
-            border: `1px solid ${gmColor}55`,
+            background: `${gmColor}20`,
+            border: `1.5px solid ${gmColor}55`,
             color: gmColor,
             fontFamily: "var(--f-mono)",
-            fontSize: "9px",
-            letterSpacing: "0.05em",
+            fontSize: "10px",
+            fontWeight: 600,
+            letterSpacing: "0.04em",
+            transition: "background 200ms ease, border-color 200ms ease",
           }}
         >
           {gmLabel}
         </span>
+        <div className="flex flex-col min-w-0">
+          <span
+            className="text-sm font-semibold leading-tight"
+            style={{ color: "var(--c-text)", fontFamily: "var(--f-sans)" }}
+          >
+            {gmFullName}
+          </span>
+          <span
+            className="text-xs leading-tight mt-0.5 hidden sm:block"
+            style={{ color: "var(--c-text-muted)", fontFamily: "var(--f-sans)" }}
+          >
+            {gmSubtitle}
+          </span>
+        </div>
         <span
-          className="text-sm font-semibold"
-          style={{ color: "var(--c-text)", fontFamily: "var(--f-sans)" }}
-        >
-          {selectedGM}
-        </span>
-        <span
-          className="text-xs ml-auto"
+          className="text-xs ml-auto shrink-0"
           style={{ color: "var(--c-text-muted)" }}
         >
           ask anything
@@ -85,13 +161,35 @@ const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus" }: Cha
       </div>
 
       {/* ── Messages ── */}
-      <div className="flex-1 overflow-y-auto min-h-0 px-3 py-3 space-y-3">
-        {messages.map((msg, i) => {
+      <div className="flex-1 overflow-y-auto min-h-0 px-3 py-3 space-y-2.5">
+
+        {/* Welcome state — show quick-start prompts when only the intro message exists */}
+        {hasOnlyWelcome && (
+          <div className="flex justify-start">
+            <span
+              className="w-0.5 rounded-full shrink-0 mr-2.5 mt-1 self-stretch"
+              style={{ background: gmColor, minHeight: "1rem" }}
+            />
+            <div
+              className="max-w-[88%] text-sm leading-relaxed rounded-xl px-3.5 py-2.5 msg-in"
+              style={{
+                background: "var(--c-hover)",
+                border: "1px solid var(--c-border-mid)",
+                color: "var(--c-text)",
+                borderBottomLeftRadius: "4px",
+              }}
+            >
+              {messages[0].text}
+            </div>
+          </div>
+        )}
+
+        {!hasOnlyWelcome && messages.map((msg, i) => {
           const isUser = msg.sender === "You";
           return (
             <div
               key={i}
-              className={`flex ${isUser ? "justify-end" : "justify-start"}`}
+              className={`flex ${isUser ? "justify-end" : "justify-start"} msg-in`}
             >
               {!isUser && (
                 <span
@@ -117,7 +215,9 @@ const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus" }: Cha
                       }
                 }
               >
-                {msg.text}
+                {isUser
+                  ? msg.text
+                  : renderChessText(msg.text, gmColor)}
               </div>
             </div>
           );
@@ -144,10 +244,11 @@ const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus" }: Cha
                   className="thinking-bar rounded-full"
                   style={{
                     width: "5px",
-                    height: "5px",
+                    height: "14px",
                     background: gmColor,
-                    animationDelay: `${i * 0.15}s`,
+                    animationDelay: `${i * 0.18}s`,
                     display: "inline-block",
+                    opacity: 0.8,
                   }}
                 />
               ))}
@@ -160,21 +261,49 @@ const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus" }: Cha
 
       {/* ── Quick ask chips ── */}
       <div
-        className="flex gap-1.5 px-3 pt-2 pb-1 overflow-x-auto shrink-0"
+        className="flex gap-1.5 px-3 pt-2 pb-1.5 overflow-x-auto shrink-0"
         style={{ borderTop: "1px solid var(--c-border)" }}
       >
+        {/* Opening chip — shows if an opening is detected */}
+        {detectedOpening && (
+          <button
+            onClick={() => onSubmit(`Explain the ${detectedOpening.name.split(" — ")[0]}`)}
+            disabled={thinking}
+            className="shrink-0 text-xs px-2.5 py-1 rounded-full disabled:opacity-40"
+            style={{
+              background: "var(--c-gold-dim)",
+              border: "1px solid rgba(200,144,64,0.3)",
+              color: "var(--c-gold)",
+              fontFamily: "var(--f-sans)",
+              whiteSpace: "nowrap",
+              transition: "background 150ms ease, border-color 150ms ease",
+              cursor: "pointer",
+            }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLButtonElement).style.background = "rgba(200,144,64,0.2)";
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLButtonElement).style.background = "var(--c-gold-dim)";
+            }}
+          >
+            📖 {detectedOpening.name.split(" — ")[0]}
+          </button>
+        )}
+
         {QUICK_ASKS.map((q) => (
           <button
             key={q}
             onClick={() => onSubmit(q)}
             disabled={thinking}
-            className="shrink-0 text-xs px-2.5 py-1 rounded-full transition-all duration-150 disabled:opacity-40"
+            className="shrink-0 text-xs px-2.5 py-1 rounded-full disabled:opacity-40"
             style={{
               background: "var(--c-raised)",
               border: "1px solid var(--c-border-bright)",
               color: "var(--c-text-soft)",
               fontFamily: "var(--f-sans)",
               whiteSpace: "nowrap",
+              transition: "background 150ms ease, border-color 150ms ease, color 150ms ease",
+              cursor: "pointer",
             }}
             onMouseEnter={(e) => {
               (e.currentTarget as HTMLButtonElement).style.borderColor = gmColor;
@@ -197,30 +326,53 @@ const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus" }: Cha
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && !e.shiftKey && handleSend()}
-          placeholder={`Ask ${selectedGM}…`}
-          className="flex-1 text-sm rounded-lg px-3.5 py-2.5 transition-all duration-150 focus:outline-none"
+          placeholder={`Ask ${gmFullName.split(" ")[0]}…`}
+          disabled={thinking}
+          className="flex-1 text-sm rounded-lg px-3.5 py-2.5 focus:outline-none"
           style={{
             background: "var(--c-raised)",
             border: "1px solid var(--c-border-bright)",
             color: "var(--c-text)",
             fontFamily: "var(--f-sans)",
+            transition: "border-color 150ms ease, box-shadow 150ms ease",
           }}
           onFocus={(e) => {
             e.currentTarget.style.borderColor = gmColor;
+            e.currentTarget.style.boxShadow = `0 0 0 3px ${gmColor}18`;
           }}
           onBlur={(e) => {
             e.currentTarget.style.borderColor = "var(--c-border-bright)";
+            e.currentTarget.style.boxShadow = "none";
           }}
         />
         <button
           onClick={handleSend}
           disabled={!input.trim() || thinking}
-          className="shrink-0 px-4 py-2.5 rounded-lg text-sm font-medium transition-all duration-150 disabled:opacity-40 disabled:cursor-not-allowed"
+          className="shrink-0 px-4 py-2.5 rounded-lg text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed"
           style={{
             background: `${gmColor}22`,
             border: `1px solid ${gmColor}66`,
             color: gmColor,
             fontFamily: "var(--f-sans)",
+            transition: "background 150ms ease, box-shadow 150ms ease, transform 80ms ease",
+          }}
+          onMouseEnter={(e) => {
+            if (!(e.currentTarget as HTMLButtonElement).disabled) {
+              (e.currentTarget as HTMLButtonElement).style.background = `${gmColor}33`;
+              (e.currentTarget as HTMLButtonElement).style.boxShadow = `0 0 8px ${gmColor}30`;
+            }
+          }}
+          onMouseLeave={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.background = `${gmColor}22`;
+            (e.currentTarget as HTMLButtonElement).style.boxShadow = "none";
+          }}
+          onMouseDown={(e) => {
+            if (!(e.currentTarget as HTMLButtonElement).disabled) {
+              (e.currentTarget as HTMLButtonElement).style.transform = "scale(0.95)";
+            }
+          }}
+          onMouseUp={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.transform = "scale(1)";
           }}
         >
           Send

--- a/src/components/EvalBar.tsx
+++ b/src/components/EvalBar.tsx
@@ -11,14 +11,15 @@ function cpToPercent(cp: number): number {
 }
 
 const EvalBar: React.FC<EvalBarProps> = ({ evalScore, mateIn, thinking }) => {
-  const { whitePercent, label } = useMemo(() => {
-    if (evalScore === null) return { whitePercent: 50, label: "=" };
+  const { whitePercent, label, isWhiteAhead } = useMemo(() => {
+    if (evalScore === null) return { whitePercent: 50, label: "=", isWhiteAhead: false };
 
     if (mateIn !== null) {
       const isWhiteWin = mateIn > 0;
       return {
         whitePercent: isWhiteWin ? 97 : 3,
         label: `M${Math.abs(mateIn)}`,
+        isWhiteAhead: isWhiteWin,
       };
     }
 
@@ -26,64 +27,66 @@ const EvalBar: React.FC<EvalBarProps> = ({ evalScore, mateIn, thinking }) => {
     const abs = Math.abs(evalScore);
     const pawns = (abs / 100).toFixed(abs >= 100 ? 1 : 2);
     const sign = evalScore > 0 ? "+" : evalScore < 0 ? "−" : "";
-    const label = evalScore === 0 ? "0.00" : `${sign}${pawns}`;
-    return { whitePercent: pct, label };
+    const displayLabel = evalScore === 0 ? "0.00" : `${sign}${pawns}`;
+    return { whitePercent: pct, label: displayLabel, isWhiteAhead: evalScore > 0 };
   }, [evalScore, mateIn]);
 
   const blackPercent = 100 - whitePercent;
 
-  const labelColor =
-    evalScore !== null && evalScore > 0
-      ? "#F0E8D8"
-      : evalScore !== null && evalScore < 0
-      ? "var(--c-text-soft)"
-      : "var(--c-text-muted)";
+  const labelColor = isWhiteAhead
+    ? "#F0E8D8"
+    : evalScore !== null && evalScore < 0
+    ? "var(--c-text-soft)"
+    : "var(--c-text-muted)";
+
+  const isLoading = thinking && evalScore === null;
 
   return (
-    <div className="flex flex-col items-center gap-1.5 select-none" title="Engine evaluation">
+    <div className="flex flex-col items-center gap-1.5 select-none" title={`Evaluation: ${label}`}>
       {/* ── Vertical bar (desktop) ── */}
       <div
         className="hidden md:flex flex-col h-full w-4 rounded-sm overflow-hidden"
         style={{ border: "1px solid var(--c-border-mid)", minHeight: 60 }}
       >
         <div
-          className="transition-[height] duration-700 ease-in-out"
+          className="eval-fill"
           style={{ height: `${blackPercent}%`, background: "#0a0a12" }}
         />
         <div
-          className="transition-[height] duration-700 ease-in-out"
+          className="eval-fill"
           style={{ height: `${whitePercent}%`, background: "#F0E8D8" }}
         />
       </div>
 
       {/* ── Horizontal bar (mobile) ── */}
       <div
-        className="flex md:hidden w-full h-3 rounded-sm overflow-hidden"
+        className="flex md:hidden w-full h-2.5 rounded-sm overflow-hidden"
         style={{ border: "1px solid var(--c-border-mid)" }}
       >
         <div
-          className="transition-[width] duration-700 ease-in-out"
+          className="eval-fill"
           style={{ width: `${whitePercent}%`, background: "#F0E8D8" }}
         />
         <div
-          className="transition-[width] duration-700 ease-in-out"
+          className="eval-fill"
           style={{ width: `${blackPercent}%`, background: "#0a0a12" }}
         />
       </div>
 
       {/* ── Score label ── */}
       <div
-        className="w-full text-center tabular-nums transition-opacity duration-300"
+        className="w-full text-center tabular-nums"
         style={{
           color: labelColor,
           fontFamily: "var(--f-mono)",
           fontSize: "10px",
           fontWeight: 600,
-          opacity: thinking && evalScore === null ? 0.3 : 1,
+          opacity: isLoading ? 0.3 : 1,
           letterSpacing: "0.02em",
+          transition: "opacity 300ms ease, color 300ms ease",
         }}
       >
-        {thinking && evalScore === null ? "…" : label}
+        {isLoading ? "…" : label}
       </div>
     </div>
   );

--- a/src/components/MoveNotation.tsx
+++ b/src/components/MoveNotation.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useRef } from "react";
 
 interface MoveNotationProps {
-  /** SAN moves from game start. sanMoves[i] transitions history[i] → history[i+1]. */
   sanMoves: string[];
-  /** Current history index (0 = start position, 1 = after move 1, etc.) */
   currentIndex: number;
   onNavigate: (index: number) => void;
 }
@@ -30,7 +28,6 @@ const MoveNotation: React.FC<MoveNotationProps> = ({ sanMoves, currentIndex, onN
   const containerRef = useRef<HTMLDivElement>(null);
   const activeRef = useRef<HTMLButtonElement>(null);
 
-  // Auto-scroll active move into view
   useEffect(() => {
     if (activeRef.current && containerRef.current) {
       activeRef.current.scrollIntoView({ block: "nearest", behavior: "smooth" });
@@ -40,7 +37,7 @@ const MoveNotation: React.FC<MoveNotationProps> = ({ sanMoves, currentIndex, onN
   if (sanMoves.length === 0) {
     return (
       <div
-        className="flex items-center justify-center py-3 text-xs"
+        className="flex items-center justify-center py-2 text-xs"
         style={{ color: "var(--c-text-muted)", fontFamily: "var(--f-mono)" }}
       >
         No moves yet
@@ -53,7 +50,7 @@ const MoveNotation: React.FC<MoveNotationProps> = ({ sanMoves, currentIndex, onN
   return (
     <div
       ref={containerRef}
-      className="flex flex-wrap gap-x-1 gap-y-0.5 overflow-y-auto"
+      className="flex flex-wrap gap-x-0.5 gap-y-0.5 overflow-y-auto"
       style={{ maxHeight: "5rem", scrollbarWidth: "none" }}
     >
       {/* Start position button */}
@@ -62,8 +59,17 @@ const MoveNotation: React.FC<MoveNotationProps> = ({ sanMoves, currentIndex, onN
         className="text-xs px-1.5 py-0.5 rounded transition-all duration-100"
         style={
           currentIndex === 0
-            ? { background: "var(--c-gold-dim)", color: "var(--c-gold-bright)", border: "1px solid var(--c-gold)" }
-            : { color: "var(--c-text-muted)", border: "1px solid transparent" }
+            ? {
+                background: "var(--c-gold-dim)",
+                color: "var(--c-gold-bright)",
+                border: "1px solid var(--c-gold)",
+                fontFamily: "var(--f-mono)",
+              }
+            : {
+                color: "var(--c-text-muted)",
+                border: "1px solid transparent",
+                fontFamily: "var(--f-mono)",
+              }
         }
       >
         ⊙
@@ -73,7 +79,7 @@ const MoveNotation: React.FC<MoveNotationProps> = ({ sanMoves, currentIndex, onN
         <React.Fragment key={pair.number}>
           {/* Move number */}
           <span
-            className="text-xs self-center tabular-nums select-none"
+            className="text-xs self-center tabular-nums select-none px-0.5"
             style={{ color: "var(--c-text-muted)", fontFamily: "var(--f-mono)" }}
           >
             {pair.number}.
@@ -81,38 +87,70 @@ const MoveNotation: React.FC<MoveNotationProps> = ({ sanMoves, currentIndex, onN
 
           {/* White move */}
           {pair.white && (
-            <button
-              ref={currentIndex === pair.white.index ? activeRef : undefined}
-              onClick={() => onNavigate(pair.white!.index)}
-              className="text-xs px-1.5 py-0.5 rounded transition-all duration-100"
-              style={
-                currentIndex === pair.white.index
-                  ? { background: "var(--c-gold-dim)", color: "var(--c-gold-bright)", border: "1px solid var(--c-gold)", fontFamily: "var(--f-mono)" }
-                  : { color: "var(--c-text-soft)", border: "1px solid transparent", fontFamily: "var(--f-mono)" }
-              }
-            >
-              {pair.white.san}
-            </button>
+            <MoveButton
+              san={pair.white.san}
+              index={pair.white.index}
+              currentIndex={currentIndex}
+              onNavigate={onNavigate}
+              activeRef={currentIndex === pair.white.index ? activeRef : undefined}
+            />
           )}
 
           {/* Black move */}
           {pair.black && (
-            <button
-              ref={currentIndex === pair.black.index ? activeRef : undefined}
-              onClick={() => onNavigate(pair.black!.index)}
-              className="text-xs px-1.5 py-0.5 rounded transition-all duration-100"
-              style={
-                currentIndex === pair.black.index
-                  ? { background: "var(--c-gold-dim)", color: "var(--c-gold-bright)", border: "1px solid var(--c-gold)", fontFamily: "var(--f-mono)" }
-                  : { color: "var(--c-text-soft)", border: "1px solid transparent", fontFamily: "var(--f-mono)" }
-              }
-            >
-              {pair.black.san}
-            </button>
+            <MoveButton
+              san={pair.black.san}
+              index={pair.black.index}
+              currentIndex={currentIndex}
+              onNavigate={onNavigate}
+              activeRef={currentIndex === pair.black.index ? activeRef : undefined}
+            />
           )}
         </React.Fragment>
       ))}
     </div>
+  );
+};
+
+interface MoveButtonProps {
+  san: string;
+  index: number;
+  currentIndex: number;
+  onNavigate: (index: number) => void;
+  activeRef?: React.RefObject<HTMLButtonElement | null>;
+}
+
+const MoveButton: React.FC<MoveButtonProps> = ({ san, index, currentIndex, onNavigate, activeRef }) => {
+  const isActive = currentIndex === index;
+
+  return (
+    <button
+      ref={activeRef}
+      onClick={() => onNavigate(index)}
+      className="text-xs px-1.5 py-0.5 rounded"
+      style={{
+        background: isActive ? "var(--c-gold-dim)" : "transparent",
+        color: isActive ? "var(--c-gold-bright)" : "var(--c-text-soft)",
+        border: `1px solid ${isActive ? "var(--c-gold)" : "transparent"}`,
+        fontFamily: "var(--f-mono)",
+        transition: "background 100ms ease, color 100ms ease, border-color 100ms ease",
+        fontWeight: isActive ? 600 : 400,
+      }}
+      onMouseEnter={(e) => {
+        if (!isActive) {
+          (e.currentTarget as HTMLButtonElement).style.background = "var(--c-hover)";
+          (e.currentTarget as HTMLButtonElement).style.color = "var(--c-text)";
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (!isActive) {
+          (e.currentTarget as HTMLButtonElement).style.background = "transparent";
+          (e.currentTarget as HTMLButtonElement).style.color = "var(--c-text-soft)";
+        }
+      }}
+    >
+      {san}
+    </button>
   );
 };
 

--- a/src/components/PersonalitySelector.tsx
+++ b/src/components/PersonalitySelector.tsx
@@ -1,9 +1,24 @@
 import React from "react";
 
 const PERSONALITIES = [
-  { name: "Magnus", color: "var(--c-gm-magnus)", short: "Magnus" },
-  { name: "Hikaru", color: "var(--c-gm-hikaru)", short: "Hikaru" },
-  { name: "Bobby",  color: "var(--c-gm-bobby)",  short: "Bobby"  },
+  {
+    name: "Magnus",
+    full: "Magnus Carlsen",
+    color: "var(--c-gm-magnus)",
+    subtitle: "Norwegian World Champion",
+  },
+  {
+    name: "Hikaru",
+    full: "Hikaru Nakamura",
+    color: "var(--c-gm-hikaru)",
+    subtitle: "American Speed Chess Legend",
+  },
+  {
+    name: "Bobby",
+    full: "Bobby Fischer",
+    color: "var(--c-gm-bobby)",
+    subtitle: "11th World Champion",
+  },
 ];
 
 interface PersonalitySelectorProps {
@@ -14,23 +29,36 @@ interface PersonalitySelectorProps {
 const PersonalitySelector: React.FC<PersonalitySelectorProps> = ({ selected, onSelect }) => {
   return (
     <div className="flex items-center gap-1">
-      {PERSONALITIES.map(({ name, color, short }) => {
+      {PERSONALITIES.map(({ name, full, color, subtitle }) => {
         const isActive = selected === name;
         return (
           <button
             key={name}
             onClick={() => onSelect(name)}
-            className="relative px-3 py-1.5 rounded-lg text-sm font-medium transition-all duration-150 focus:outline-none"
+            className="relative px-3 py-1.5 rounded-lg text-sm font-medium focus:outline-none group"
             style={{
               background: isActive ? `${color}18` : "transparent",
               border: `1px solid ${isActive ? color : "var(--c-border-mid)"}`,
               color: isActive ? color : "var(--c-text-soft)",
               fontFamily: "var(--f-sans)",
               letterSpacing: "0.01em",
+              transition: "background 150ms ease, border-color 150ms ease, color 150ms ease, box-shadow 150ms ease",
             }}
-            title={`Switch to ${name}`}
+            onMouseEnter={(e) => {
+              if (!isActive) {
+                (e.currentTarget as HTMLButtonElement).style.borderColor = `${color}66`;
+                (e.currentTarget as HTMLButtonElement).style.color = color;
+              }
+            }}
+            onMouseLeave={(e) => {
+              if (!isActive) {
+                (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--c-border-mid)";
+                (e.currentTarget as HTMLButtonElement).style.color = "var(--c-text-soft)";
+              }
+            }}
+            title={`${full} — ${subtitle}`}
           >
-            {short}
+            {name}
             {isActive && (
               <span
                 className="absolute bottom-0.5 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full"

--- a/src/features/ChessPanel.tsx
+++ b/src/features/ChessPanel.tsx
@@ -30,6 +30,12 @@ interface ChessPanelProps {
   onNavigate: (index: number) => void;
 }
 
+const GM_COLORS: Record<string, string> = {
+  Magnus: "var(--c-gm-magnus)",
+  Hikaru: "var(--c-gm-hikaru)",
+  Bobby:  "var(--c-gm-bobby)",
+};
+
 const ChessPanel: React.FC<ChessPanelProps> = ({
   position,
   onMove,
@@ -52,9 +58,7 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
   onNavigate,
 }) => {
   const [boardFlipped, setBoardFlipped] = useState(false);
-  // Which engine line is selected for preview (-1 = none)
   const [selectedLine, setSelectedLine] = useState(-1);
-  // Which move within the selected line we're previewing (-1 = not yet stepping)
   const [pvStep, setPvStep] = useState(-1);
 
   const isPreviewing = selectedLine >= 0 && pvStep >= 0;
@@ -64,7 +68,6 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
     [topLines, selectedLine]
   );
 
-  // Board FEN while stepping through a line
   const previewFen = useMemo(() => {
     if (!isPreviewing || activePv.length === 0) return null;
     const chess = new Chess(position);
@@ -86,21 +89,17 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
 
   const handleSelectLine = useCallback((i: number) => {
     if (i === selectedLine) {
-      // Toggle off
       setSelectedLine(-1);
       setPvStep(-1);
     } else {
       setSelectedLine(i);
-      setPvStep(0); // Auto-preview first move
+      setPvStep(0);
     }
   }, [selectedLine]);
 
   const handlePvStep = useCallback((dir: 1 | -1) => {
     setPvStep((s) => {
-      if (dir === -1) {
-        const next = s - 1;
-        return next < 0 ? 0 : next;
-      }
+      if (dir === -1) return s <= 0 ? 0 : s - 1;
       const next = s + 1;
       return next >= activePv.length ? s : next;
     });
@@ -111,16 +110,12 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
     setPvStep(-1);
   }, []);
 
-  const gmColor: Record<string, string> = {
-    Magnus: "var(--c-gm-magnus)",
-    Hikaru: "var(--c-gm-hikaru)",
-    Bobby:  "var(--c-gm-bobby)",
-  };
+  const gmColor = GM_COLORS[selectedGM] ?? "var(--c-gold)";
 
   return (
     <div
-      className="panel p-3 shadow-2xl w-full"
-      style={{ boxShadow: "0 16px 48px rgba(0,0,0,0.7)" }}
+      className="panel p-3 w-full"
+      style={{ boxShadow: "0 16px 48px rgba(0,0,0,0.6)" }}
     >
       {/* ── Board + eval bar row ── */}
       <div className="flex gap-2 items-stretch">
@@ -132,7 +127,6 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
         {/* Board column */}
         <div className="flex-1 flex flex-col min-w-0 gap-1">
           <CapturedPieces fen={position} side="top" />
-
           <ChessBoard
             key={isPreviewing ? `pv-${selectedLine}-${pvStep}` : "game"}
             position={isPreviewing && previewFen ? previewFen : position}
@@ -144,7 +138,6 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
             animationDuration={isPreviewing ? 0 : 200}
             boardOrientation={boardFlipped ? "black" : "white"}
           />
-
           <CapturedPieces fen={position} side="bottom" />
         </div>
       </div>
@@ -184,31 +177,54 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
 
       {/* ── Control buttons ── */}
       <div
-        className="flex flex-wrap gap-2 mt-3 pt-3"
+        className="flex flex-wrap items-center gap-1.5 mt-3 pt-3"
         style={{ borderTop: "1px solid var(--c-border)" }}
       >
-        <button onClick={onBack} className="btn text-sm">← Back</button>
-        <button onClick={onForward} disabled={disableForward} className="btn text-sm">
-          Forward →
+        {/* Navigation group */}
+        <div className="flex gap-1">
+          <button onClick={onBack} className="btn text-xs px-2.5 py-1.5" title="Go back one move (←)">
+            ←
+          </button>
+          <button
+            onClick={onForward}
+            disabled={disableForward}
+            className="btn text-xs px-2.5 py-1.5"
+            title="Go forward one move (→)"
+          >
+            →
+          </button>
+        </div>
+
+        <button onClick={onUndo} className="btn text-xs px-2.5 py-1.5">
+          Undo
         </button>
-        <button onClick={onUndo} className="btn text-sm">Undo</button>
         <button
           onClick={() => setBoardFlipped((f) => !f)}
-          className="btn text-sm"
+          className="btn text-xs px-2.5 py-1.5"
           title="Flip board"
         >
-          ⇅
+          ⇅ Flip
         </button>
+
+        {/* Ask GM button — right-aligned, GM-colored */}
         <button
           onClick={onAsk}
-          className="btn text-sm ml-auto"
+          className="btn text-xs ml-auto px-3 py-1.5 font-semibold"
           style={{
-            background: `${gmColor[selectedGM] ?? "var(--c-gold)"}18`,
-            borderColor: `${gmColor[selectedGM] ?? "var(--c-gold)"}66`,
-            color: gmColor[selectedGM] ?? "var(--c-gold)",
+            background: `${gmColor}18`,
+            borderColor: `${gmColor}66`,
+            color: gmColor,
+          }}
+          onMouseEnter={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.background = `${gmColor}28`;
+            (e.currentTarget as HTMLButtonElement).style.boxShadow = `0 0 8px ${gmColor}25`;
+          }}
+          onMouseLeave={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.background = `${gmColor}18`;
+            (e.currentTarget as HTMLButtonElement).style.boxShadow = "none";
           }}
         >
-          Ask {selectedGM}
+          Ask {selectedGM} →
         </button>
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,22 +1,24 @@
+@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=JetBrains+Mono:wght@400;600&display=swap');
 @import "tailwindcss";
 
 :root {
   /* ── Backgrounds ── */
-  --c-bg:       #09090F;   /* deepest — page base */
-  --c-surface:  #0F0F18;   /* card surfaces */
-  --c-raised:   #161622;   /* inputs, elevated elements */
-  --c-hover:    #1E1E2C;   /* hover state */
+  --c-bg:       #08080E;
+  --c-surface:  #0E0E17;
+  --c-raised:   #151521;
+  --c-hover:    #1C1C2A;
 
   /* ── Borders ── */
-  --c-border:       #1C1C2C;
-  --c-border-mid:   #262638;
-  --c-border-bright:#323248;
+  --c-border:        #1A1A2A;
+  --c-border-mid:    #242438;
+  --c-border-bright: #303048;
 
   /* ── Gold accent — brass lamp in a mahogany study ── */
   --c-gold:       #C89040;
   --c-gold-bright:#E4A84C;
   --c-gold-dim:   rgba(200, 144, 64, 0.14);
   --c-gold-glow:  rgba(200, 144, 64, 0.08);
+  --c-gold-ring:  rgba(200, 144, 64, 0.35);
 
   /* ── Interactive blue ── */
   --c-blue:     #4674E8;
@@ -25,15 +27,15 @@
   /* ── Engine line colors — tactical beams ── */
   --c-line1:        #38C87A;
   --c-line1-bg:     rgba(56, 200, 122, 0.07);
-  --c-line1-border: rgba(56, 200, 122, 0.20);
+  --c-line1-border: rgba(56, 200, 122, 0.22);
 
   --c-line2:        #E89C20;
   --c-line2-bg:     rgba(232, 156, 32, 0.06);
-  --c-line2-border: rgba(232, 156, 32, 0.18);
+  --c-line2-border: rgba(232, 156, 32, 0.20);
 
   --c-line3:        #6880A4;
   --c-line3-bg:     rgba(104, 128, 164, 0.05);
-  --c-line3-border: rgba(104, 128, 164, 0.15);
+  --c-line3-border: rgba(104, 128, 164, 0.16);
 
   /* ── GM identity colors ── */
   --c-gm-magnus: #4674E8;
@@ -49,6 +51,11 @@
   --f-serif: 'Cormorant Garamond', Georgia, serif;
   --f-mono:  'JetBrains Mono', 'Fira Code', monospace;
   --f-sans:  'DM Sans', system-ui, sans-serif;
+
+  /* ── Transitions ── */
+  --t-fast:   100ms ease;
+  --t-base:   150ms ease;
+  --t-slow:   250ms ease;
 }
 
 *, *::before, *::after {
@@ -66,59 +73,128 @@ body {
   font-family: var(--f-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+/* ── Text selection ── */
+::selection {
+  background: var(--c-gold-dim);
+  color: var(--c-gold-bright);
 }
 
 /* ── Refined scrollbars ── */
-::-webkit-scrollbar { width: 3px; height: 3px; }
+::-webkit-scrollbar { width: 4px; height: 4px; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--c-border-bright); border-radius: 2px; }
+::-webkit-scrollbar-thumb {
+  background: var(--c-border-bright);
+  border-radius: 4px;
+  transition: background var(--t-base);
+}
 ::-webkit-scrollbar-thumb:hover { background: var(--c-gold); }
+
+/* ── Focus ring reset ── */
+:focus { outline: none; }
+:focus-visible {
+  outline: 2px solid var(--c-gold-ring);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
 
 /* ── Base component classes ── */
 @layer components {
   .btn {
-    @apply rounded-lg px-3 py-2 text-sm font-medium transition-all duration-150 focus:outline-none disabled:cursor-not-allowed disabled:opacity-40 whitespace-nowrap;
+    @apply rounded-lg px-3 py-2 text-sm font-medium whitespace-nowrap;
     background: var(--c-raised);
     border: 1px solid var(--c-border-bright);
-    color: var(--c-text);
+    color: var(--c-text-soft);
     font-family: var(--f-sans);
     letter-spacing: 0.01em;
+    transition: background var(--t-base), border-color var(--t-base), color var(--t-base), box-shadow var(--t-base), transform var(--t-fast);
+    cursor: pointer;
   }
   .btn:hover:not(:disabled) {
     background: var(--c-hover);
     border-color: var(--c-gold);
     color: var(--c-gold-bright);
+    box-shadow: 0 0 0 1px var(--c-gold-glow);
+  }
+  .btn:active:not(:disabled) {
+    transform: scale(0.97);
+  }
+  .btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.35;
   }
   .btn:focus-visible {
-    outline: 1px solid var(--c-gold);
+    outline: 2px solid var(--c-gold-ring);
     outline-offset: 2px;
   }
+
   .btn-primary {
-    @apply rounded-lg px-3 py-2 text-sm font-medium transition-all duration-150 focus:outline-none disabled:cursor-not-allowed disabled:opacity-40 whitespace-nowrap;
+    @apply rounded-lg px-3 py-2 text-sm font-medium whitespace-nowrap;
     background: var(--c-gold-dim);
     border: 1px solid var(--c-gold);
     color: var(--c-gold-bright);
     font-family: var(--f-sans);
     letter-spacing: 0.01em;
+    transition: background var(--t-base), box-shadow var(--t-base), transform var(--t-fast);
+    cursor: pointer;
   }
   .btn-primary:hover:not(:disabled) {
     background: rgba(200, 144, 64, 0.22);
+    box-shadow: 0 0 12px var(--c-gold-glow);
+  }
+  .btn-primary:active:not(:disabled) {
+    transform: scale(0.97);
+  }
+  .btn-primary:disabled {
+    cursor: not-allowed;
+    opacity: 0.35;
   }
 
   .panel {
     background: var(--c-surface);
     border: 1px solid var(--c-border);
     border-radius: 0.875rem;
+    transition: border-color var(--t-slow);
+  }
+  .panel:focus-within {
+    border-color: var(--c-border-mid);
   }
 }
 
 /* ── Thinking animation ── */
 @keyframes thinking-pulse {
-  0%, 100% { opacity: 0.3; transform: scaleY(0.6); }
-  50%       { opacity: 1;   transform: scaleY(1.0); }
+  0%, 100% { opacity: 0.25; transform: scaleY(0.55); }
+  50%       { opacity: 1.0;  transform: scaleY(1.0); }
 }
 .thinking-bar {
-  animation: thinking-pulse 1.2s ease-in-out infinite;
+  animation: thinking-pulse 1.1s ease-in-out infinite;
+  transform-origin: center bottom;
 }
-.thinking-bar:nth-child(2) { animation-delay: 0.15s; }
-.thinking-bar:nth-child(3) { animation-delay: 0.30s; }
+.thinking-bar:nth-child(2) { animation-delay: 0.18s; }
+.thinking-bar:nth-child(3) { animation-delay: 0.36s; }
+
+/* ── Fade-in for new chat messages ── */
+@keyframes msg-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.msg-in {
+  animation: msg-in 0.2s ease forwards;
+}
+
+/* ── Opening badge pulse ── */
+@keyframes badge-in {
+  from { opacity: 0; transform: scale(0.92); }
+  to   { opacity: 1; transform: scale(1); }
+}
+.badge-in {
+  animation: badge-in 0.25s ease forwards;
+}
+
+/* ── Smooth eval bar transition ── */
+.eval-fill {
+  transition: height 0.8s cubic-bezier(0.4, 0, 0.2, 1),
+              width  0.8s cubic-bezier(0.4, 0, 0.2, 1);
+}

--- a/src/utils/openingDetection.ts
+++ b/src/utils/openingDetection.ts
@@ -1,0 +1,47 @@
+import { OPENINGS } from "../data/openings";
+
+export interface DetectedOpening {
+  name: string;
+  eco: string;
+  matchedMoves: number;
+}
+
+function countPrefixMatch(actual: string[], reference: string[]): number {
+  let count = 0;
+  for (let i = 0; i < reference.length && i < actual.length; i++) {
+    if (actual[i] !== reference[i]) break;
+    count++;
+  }
+  return count;
+}
+
+export function detectOpening(uciMoves: string[]): DetectedOpening | null {
+  if (uciMoves.length < 2) return null;
+
+  let bestMatch: DetectedOpening | null = null;
+  let bestLen = 1;
+
+  for (const opening of OPENINGS) {
+    const mainLen = countPrefixMatch(uciMoves, opening.moves);
+    if (mainLen > bestLen) {
+      bestLen = mainLen;
+      bestMatch = { name: opening.name, eco: opening.eco, matchedMoves: mainLen };
+    }
+
+    if (opening.variations) {
+      for (const variation of opening.variations) {
+        const varLen = countPrefixMatch(uciMoves, variation.moves);
+        if (varLen > bestLen) {
+          bestLen = varLen;
+          bestMatch = {
+            name: `${opening.name} — ${variation.name}`,
+            eco: variation.eco ?? opening.eco,
+            matchedMoves: varLen,
+          };
+        }
+      }
+    }
+  }
+
+  return bestMatch;
+}


### PR DESCRIPTION
UI / Design:
- Add Google Fonts (Cormorant Garamond, DM Sans, JetBrains Mono) — the
  font stack now actually loads instead of falling back to system fonts
- Polish CSS: smooth eval-fill transitions, msg-in/badge-in keyframe
  animations, better focus rings, btn press scale feedback, refined
  scrollbars, ::selection highlighting in gold
- Opening detection badge in header (desktop + mobile) — shows ECO code
  and opening name once the position matches a known line
- ChatWindow: full GM names + subtitle ("World Champion · Highest Elo")
  in chat header; chess piece/move tokens rendered in styled spans
  (Nf3, O-O, Bxe5+); dynamic opening chip in quick-ask row
- MoveNotation: hover highlight on non-active moves; extracted
  MoveButton sub-component for cleaner code
- ChessPanel: tighter control row (← → Undo Flip | Ask GM →); Ask GM
  button has glow-on-hover; navigation arrows use compact px-2.5 style
- PersonalitySelector: full-name tooltip; hover tint in GM color
- EvalBar: uses new .eval-fill CSS class for smoother animation

AI Coaching:
- Dramatically expanded GM personalities — Magnus gets Ruy Lopez /
  Catalan / endgame-grinder details; Hikaru gets streaming culture and
  Bongcloud lore; Bobby gets historical context, "chess is war" quotes
- Server prompt now includes: material balance string, position type
  (open/closed/semi-open/endgame), king safety (castled vs. center),
  and detected opening name — all injected as structured context
- max_tokens bumped 450 → 600 for richer responses
- PV line length extended from 6 to 7 moves

Bug fix:
- handleQuestion now uses sanMoves.slice(0, historyIndex) instead of
  chessRef.current.history() — the latter returns [] after any
  back/forward navigation via loadFenAt; this was silently stripping
  all move context from the chat prompt

New:
- src/utils/openingDetection.ts — pure utility that matches the current
  UCI move sequence against the opening database (main lines +
  variations) and returns the deepest prefix match with name + ECO

https://claude.ai/code/session_012dTPzKmBpGhWyBAkXzpNbv