### PR TITLE
feat: coaching quality & UI v2 — all 10 improvements

### DIFF
--- a/server/gmPersonalities.js
+++ b/server/gmPersonalities.js
@@ -11,6 +11,14 @@ const gmPersonalities = {
     name: "Magnus Carlsen",
     systemPrompt: `You are Magnus Carlsen, the Norwegian chess prodigy who became World Chess Champion in 2013 and held the title until 2023. You achieved the highest FIDE rating in history (2882) and are universally considered the greatest chess player of all time.
 
+OFF-TOPIC RULE (HIGHEST PRIORITY):
+If the user asks about ANYTHING unrelated to chess — programming, cooking, politics, sports (non-chess), relationships, general knowledge, or any non-chess topic — you must respond with a short, dry, deadpan dismissal in your voice and NOTHING else. Examples:
+- "I came here to talk about chess. This is not chess."
+- "Honestly? I have no opinion on that. Ask me about the Ruy Lopez instead."
+- "That's… not chess. I'm not sure why you're asking me this."
+- "I don't really concern myself with things that aren't chess. Show me a position."
+Keep it 1-2 sentences maximum. Do not apologize, do not explain at length, do not answer the off-topic question under any circumstances.
+
 IDENTITY & BACKGROUND:
 - Norwegian, born 1990. Became a grandmaster at age 13.
 - Known for your "universal" style — supremely strong in all phases (opening, middlegame, endgame).
@@ -46,6 +54,14 @@ SPEAKING STYLE:
   Hikaru: {
     name: "Hikaru Nakamura",
     systemPrompt: `You are Hikaru Nakamura, the American super-grandmaster, five-time U.S. Chess Champion, and one of the most popular chess streamers in the world. You've been ranked #1 in the world in classical, rapid, and blitz. You're a household name in modern chess culture.
+
+OFF-TOPIC RULE (HIGHEST PRIORITY):
+If the user asks about ANYTHING unrelated to chess — programming, cooking, politics, sports (non-chess), relationships, general knowledge, or any non-chess topic — you must respond with a short, reactive streaming-style dismissal in your voice and NOTHING else. Examples:
+- "Chat, are you serious right now? We're playing chess, not googling stuff."
+- "Nah nah nah — I'm not your search engine, bro. Show me a chess position."
+- "No shot I'm answering that. I'm a chess player. Chess. Let's go."
+- "Bro what? That's not chess. That's not even close to chess. What are we doing."
+Keep it 1-2 sentences maximum. Do not answer the off-topic question under any circumstances.
 
 IDENTITY & BACKGROUND:
 - American, born 1987 in Hirakata, Japan. Became a grandmaster at age 15 — second youngest American ever.
@@ -83,6 +99,14 @@ SPEAKING STYLE:
   Bobby: {
     name: "Bobby Fischer",
     systemPrompt: `You are Bobby Fischer, the 11th World Chess Champion and arguably the most gifted chess mind who ever lived. You destroyed the Soviet chess machine almost single-handedly and won the 1972 World Championship match against Boris Spassky with an iconic performance that captured the entire world's attention.
+
+OFF-TOPIC RULE (HIGHEST PRIORITY):
+If the user asks about ANYTHING unrelated to chess — programming, cooking, politics, sports (non-chess), relationships, general knowledge, or any non-chess topic — you must respond with a short, dramatic, contemptuous dismissal in your voice and NOTHING else. Examples:
+- "I didn't master the greatest game ever played to answer questions like this. Show me a chess position."
+- "You're wasting my time. This is not chess. I don't waste time on things that aren't chess."
+- "What is this? I came here to talk about chess — the greatest pursuit of the human mind. Not this."
+- "That is completely irrelevant. We are here to talk about chess and nothing else. Now show me the board."
+Keep it 1-2 sentences maximum. Intense and dismissive — Bobby Fischer does not suffer fools gladly. Do not answer the off-topic question under any circumstances.
 
 IDENTITY & BACKGROUND:
 - American, born 1943 in Chicago. Became a grandmaster at age 15 — the youngest in history at the time.

--- a/server/index.js
+++ b/server/index.js
@@ -272,6 +272,72 @@ CURRENT POSITION (Move ${moveNum}, ${sideToMove} to play)
 }
 
 /**
+ * Sanitize user input: strip control chars, enforce max length.
+ */
+function sanitizeInput(value, maxLen = 1000) {
+  if (typeof value !== "string") return "";
+  // Remove control characters (except \n \t which are fine in text)
+  return value.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "").slice(0, maxLen);
+}
+
+/**
+ * Classify question to determine expected response length.
+ * Returns "tactical" | "conceptual" | "theory"
+ */
+function classifyQuestion(question) {
+  const q = question.toLowerCase();
+  if (/\b(best move|what('s| is) the move|blunder|tactic|checkmate|mate in|combination|fork|pin|skewer|sacrifice|trap)\b/.test(q)) {
+    return "tactical";
+  }
+  if (/\b(opening|theory|variation|line|gambit|sicilian|french|caro|slav|indian|ruy|london|catalan|nimzo|grünfeld|grunfeld)\b/.test(q)) {
+    return "theory";
+  }
+  return "conceptual";
+}
+
+/**
+ * Extract SAN tokens from a text string.
+ */
+function extractSanTokens(text) {
+  const SAN_RE = /\b(O-O-O|O-O|[KQRBN][a-h]?[1-8]?x?[a-h][1-8](?:=[KQRBN])?[+#]?|[a-h][1-8]|[a-h]x[a-h][1-8](?:=[KQRBN])?[+#]?)\b/g;
+  return [...text.matchAll(SAN_RE)].map(m => m[0]);
+}
+
+/**
+ * Validate that all recommended moves in a response are legal in the position.
+ * Returns { valid: boolean, illegalMoves: string[] }
+ */
+function validateResponseMoves(responseText, fen) {
+  try {
+    const chess = new Chess(fen);
+    const legalSans = new Set(chess.moves());
+    const mentioned = extractSanTokens(responseText);
+    const illegalMoves = mentioned.filter(san => !legalSans.has(san));
+    return { valid: illegalMoves.length === 0, illegalMoves };
+  } catch {
+    return { valid: true, illegalMoves: [] };
+  }
+}
+
+/**
+ * Parse FOLLOWUPS from a response and return { text, followUps }.
+ * The model is instructed to append: FOLLOWUPS: q1 | q2 | q3
+ */
+function parseFollowUps(rawText) {
+  const marker = /\nFOLLOWUPS:\s*(.+)$/i;
+  const match = rawText.match(marker);
+  if (!match) return { text: rawText.trim(), followUps: [] };
+
+  const text = rawText.slice(0, match.index).trim();
+  const followUps = match[1]
+    .split("|")
+    .map(s => s.trim())
+    .filter(Boolean)
+    .slice(0, 3);
+  return { text, followUps };
+}
+
+/**
  * POST /api/chat
  */
 const chatLimiter = rateLimit({
@@ -284,36 +350,76 @@ const chatLimiter = rateLimit({
 
 app.post("/api/chat", chatLimiter, async (req, res) => {
   try {
-    const { selectedGM, currentFen, question, conversationHistory, moveHistory, topLines, openingName } = req.body;
+    let { selectedGM, currentFen, question, conversationHistory, moveHistory, topLines, openingName } = req.body;
 
     if (!question || !currentFen || !selectedGM) {
       return res.status(400).json({ error: "Missing required fields: question, currentFen, selectedGM" });
     }
 
+    // ── Input sanitization ──
+    question = sanitizeInput(question, 1000);
+    if (!question) return res.status(400).json({ error: "Question is empty after sanitization." });
+
+    if (!Array.isArray(topLines)) topLines = [];
+    topLines = topLines.slice(0, 5);
+
+    if (!Array.isArray(conversationHistory)) conversationHistory = [];
+    conversationHistory = conversationHistory.slice(-10);
+
+    if (!Array.isArray(moveHistory)) moveHistory = [];
+    moveHistory = moveHistory.slice(0, 200);
+
+    // ── Question classification → response length hint ──
+    const qClass = classifyQuestion(question);
+    const lengthHint =
+      qClass === "tactical"   ? "1-2 punchy sentences (it's a direct move question)" :
+      qClass === "theory"     ? "4-5 sentences (opening theory deserves context)" :
+                                "3-4 sentences (strategic/conceptual question)";
+
     const systemPrompt = buildSystemPrompt(selectedGM, currentFen, moveHistory, topLines, openingName);
 
+    // Append question classification + follow-up instructions to the system prompt
+    const fullSystemPrompt = systemPrompt +
+      `\n\nRESPONSE LENGTH FOR THIS QUESTION: ${lengthHint}\n` +
+      `After your response, on a new line append exactly: FOLLOWUPS: <q1> | <q2> | <q3>\n` +
+      `where q1/q2/q3 are 3 short natural follow-up questions a student might ask next (5-8 words each, chess-specific to this position). ` +
+      `Do not number them. Do not put quotes around them. The FOLLOWUPS line must always be present.`;
+
     const messages = [];
-
-    if (conversationHistory && conversationHistory.length > 0) {
-      for (const msg of conversationHistory) {
-        messages.push({
-          role: msg.role === "You" ? "user" : "assistant",
-          content: msg.content,
-        });
-      }
+    for (const msg of conversationHistory) {
+      messages.push({
+        role: msg.role === "You" ? "user" : "assistant",
+        content: typeof msg.content === "string" ? sanitizeInput(msg.content, 2000) : "",
+      });
     }
-
     messages.push({ role: "user", content: question });
 
-    const response = await anthropic.messages.create({
-      model: "claude-sonnet-4-6",
-      max_tokens: 600,
-      system: systemPrompt,
-      messages,
-    });
+    const callClaude = async () =>
+      anthropic.messages.create({
+        model: "claude-sonnet-4-6",
+        max_tokens: 700,
+        system: fullSystemPrompt,
+        messages,
+      });
 
-    const text = response.content[0].text;
-    res.json({ response: text });
+    let response = await callClaude();
+    let rawText = response.content[0].text;
+
+    // ── Move validation with single retry ──
+    const { valid, illegalMoves } = validateResponseMoves(rawText, currentFen);
+    if (!valid && illegalMoves.length > 0) {
+      messages.push({ role: "assistant", content: rawText });
+      messages.push({
+        role: "user",
+        content: `The move(s) ${illegalMoves.join(", ")} are not legal in this position. ` +
+          `Please correct your response using only legal moves from the engine analysis provided.`,
+      });
+      response = await callClaude();
+      rawText = response.content[0].text;
+    }
+
+    const { text, followUps } = parseFollowUps(rawText);
+    res.json({ response: text, followUps });
   } catch (error) {
     console.error("Chat API error:", error.message);
 

--- a/server/index.js
+++ b/server/index.js
@@ -267,6 +267,7 @@ CURRENT POSITION (Move ${moveNum}, ${sideToMove} to play)
   chessContext += `- Reference concrete squares, pieces, and structures — ground your advice in THIS position.\n`;
   chessContext += `- When you explain WHY a move is good, connect it to the position's key features (material, king safety, pawn structure, piece activity).\n`;
   chessContext += `- If something is off-topic, redirect in character with a brief, sharp comment.\n`;
+  chessContext += `- IMPORTANT: Write in plain conversational prose — NO markdown formatting. No asterisks for bold, no hashtags for headers, no bullet dashes, no backticks. Write exactly as you would speak to someone.\n`;
 
   return gm.systemPrompt + chessContext;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import type { Opening } from "./data/openings";
 import { detectOpening } from "./utils/openingDetection";
 import type { DetectedOpening } from "./utils/openingDetection";
 
-type ChatMessage = { sender: string; text: string };
+type ChatMessage = { sender: string; text: string; fen?: string; followUps?: string[] };
 type AppTab = "game" | "openings";
 
 async function askGM(payload: {
@@ -23,7 +23,7 @@ async function askGM(payload: {
   moveHistory?: string[];
   topLines?: EngineLineResult[];
   openingName?: string;
-}): Promise<string> {
+}): Promise<{ response: string; followUps: string[] }> {
   const res = await fetch("/api/chat", {
     method: "POST",
     headers: {
@@ -39,7 +39,7 @@ async function askGM(payload: {
   }
 
   const data = await res.json();
-  return data.response;
+  return { response: data.response ?? "", followUps: Array.isArray(data.followUps) ? data.followUps : [] };
 }
 
 function App() {
@@ -206,7 +206,7 @@ function App() {
         moveHistory = sanMoves.slice(0, historyIndex);
       }
 
-      const response = await askGM({
+      const { response, followUps } = await askGM({
         selectedGM,
         currentFen: contextFen,
         question: enrichedQuestion,
@@ -216,7 +216,10 @@ function App() {
         openingName: openingNameForServer,
       });
 
-      setChatMessages((msgs) => [...msgs, { sender: "GM", text: response }]);
+      setChatMessages((msgs) => [
+        ...msgs,
+        { sender: "GM", text: response, fen: contextFen, followUps },
+      ]);
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : "Something went wrong";
       setChatMessages((msgs) => [...msgs, { sender: "GM", text: `Error: ${errMsg}` }]);
@@ -224,6 +227,20 @@ function App() {
       setThinking(false);
     }
   };
+
+  const handleGMMove = useCallback(
+    (san: string) => {
+      const chess = new Chess(currentFen);
+      try {
+        const move = chess.move(san);
+        if (!move) return;
+        handleMove(move.from, move.to, move.promotion);
+      } catch {
+        // ignore invalid san
+      }
+    },
+    [currentFen] // eslint-disable-line react-hooks/exhaustive-deps
+  );
 
   const handleQuickAsk = () => handleQuestion("What should I play here?");
 
@@ -464,6 +481,7 @@ function App() {
               sanMoves={sanMoves}
               historyIndex={historyIndex}
               onNavigate={handleNavigate}
+              detectedOpening={activeTab === "game" ? detectedOpening : null}
             />
           </div>
         </div>
@@ -520,6 +538,7 @@ function App() {
               thinking={thinking}
               selectedGM={selectedGM}
               detectedOpening={detectedOpening}
+              onMoveClick={handleGMMove}
             />
           </div>
         </div>

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -46,12 +46,26 @@ const QUICK_ASKS = [
 // Chess notation regex — piece moves, castling, captures, pawn moves
 const CHESS_MOVE_RE = /\b(O-O-O|O-O|[KQRBN][a-h]?[1-8]?x?[a-h][1-8](?:=[KQRBN])?[+#]?|[a-h]x[a-h][1-8](?:=[KQRBN])?[+#]?)\b/g;
 
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/^#{1,6}\s+/gm, "")               // ## Heading → plain text
+    .replace(/\*\*([^*\n]+)\*\*/g, "$1")        // **bold** → bold
+    .replace(/__([^_\n]+)__/g, "$1")            // __bold__ → bold
+    .replace(/\*([^*\n]+)\*/g, "$1")            // *italic* → italic
+    .replace(/_([^_\n]+)_/g, "$1")              // _italic_ → italic
+    .replace(/^[-*•]\s+/gm, "")                // - bullet → plain
+    .replace(/^[-*_]{3,}\s*$/gm, "")           // --- horizontal rule → removed
+    .replace(/`([^`]+)`/g, "$1")               // `code` → code (keep content, strip backticks)
+    .replace(/\n{3,}/g, "\n\n")                // collapse excessive blank lines
+    .trim();
+}
+
 function renderChessText(
   text: string,
   moveColor: string,
   onMoveClick?: (san: string) => void
 ) {
-  const lines = text.split("\n");
+  const lines = stripMarkdown(text).split("\n");
   return lines.map((line, lineIdx) => {
     const parts: React.ReactNode[] = [];
     let lastIndex = 0;

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import type { DetectedOpening } from "../utils/openingDetection";
 
-type Message = { sender: string; text: string };
+type Message = { sender: string; text: string; fen?: string; followUps?: string[] };
 
 type ChatWindowProps = {
   messages: Message[];
@@ -9,6 +9,7 @@ type ChatWindowProps = {
   thinking?: boolean;
   selectedGM?: string;
   detectedOpening?: DetectedOpening | null;
+  onMoveClick?: (san: string) => void;
 };
 
 const GM_COLORS: Record<string, string> = {
@@ -42,10 +43,14 @@ const QUICK_ASKS = [
   "Why this engine move?",
 ];
 
-// Chess notation regex — piece moves, castling, captures
-const CHESS_MOVE_RE = /\b(O-O-O|O-O|[KQRBN][a-h]?[1-8]?x?[a-h][1-8](?:=[KQRBN])?[+#]?)\b/g;
+// Chess notation regex — piece moves, castling, captures, pawn moves
+const CHESS_MOVE_RE = /\b(O-O-O|O-O|[KQRBN][a-h]?[1-8]?x?[a-h][1-8](?:=[KQRBN])?[+#]?|[a-h]x[a-h][1-8](?:=[KQRBN])?[+#]?)\b/g;
 
-function renderChessText(text: string, moveColor: string) {
+function renderChessText(
+  text: string,
+  moveColor: string,
+  onMoveClick?: (san: string) => void
+) {
   const lines = text.split("\n");
   return lines.map((line, lineIdx) => {
     const parts: React.ReactNode[] = [];
@@ -57,21 +62,23 @@ function renderChessText(text: string, moveColor: string) {
       if (match.index > lastIndex) {
         parts.push(line.slice(lastIndex, match.index));
       }
+      const san = match[0];
       parts.push(
         <span
           key={`m-${lineIdx}-${match.index}`}
+          className="move-token"
+          role={onMoveClick ? "button" : undefined}
+          tabIndex={onMoveClick ? 0 : undefined}
+          onClick={onMoveClick ? () => onMoveClick(san) : undefined}
+          onKeyDown={onMoveClick ? (e) => { if (e.key === "Enter" || e.key === " ") onMoveClick(san); } : undefined}
+          title={onMoveClick ? `Play ${san}` : undefined}
           style={{
-            fontFamily: "var(--f-mono)",
-            fontSize: "0.85em",
-            fontWeight: 600,
             color: moveColor,
-            background: `${moveColor}14`,
-            borderRadius: "3px",
-            padding: "0 3px",
-            letterSpacing: "0.02em",
+            background: `${moveColor}18`,
+            border: onMoveClick ? `1px solid ${moveColor}30` : "none",
           }}
         >
-          {match[0]}
+          {san}
         </span>
       );
       lastIndex = CHESS_MOVE_RE.lastIndex;
@@ -90,18 +97,44 @@ function renderChessText(text: string, moveColor: string) {
   });
 }
 
-const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus", detectedOpening }: ChatWindowProps) => {
+const ChatWindow = ({
+  messages,
+  onSubmit,
+  thinking,
+  selectedGM = "Magnus",
+  detectedOpening,
+  onMoveClick,
+}: ChatWindowProps) => {
   const [input, setInput] = useState("");
+  const [sendConfirm, setSendConfirm] = useState(false);
+  const [avatarPulse, setAvatarPulse] = useState(false);
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const prevMessageCountRef = useRef(messages.length);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, thinking]);
 
+  // Trigger avatar pulse when a new GM message arrives
+  useEffect(() => {
+    const prev = prevMessageCountRef.current;
+    const curr = messages.length;
+    if (curr > prev) {
+      const lastMsg = messages[curr - 1];
+      if (lastMsg.sender !== "You") {
+        setAvatarPulse(true);
+        setTimeout(() => setAvatarPulse(false), 400);
+      }
+    }
+    prevMessageCountRef.current = curr;
+  }, [messages]);
+
   const handleSend = () => {
     const trimmed = input.trim();
     if (!trimmed) return;
+    setSendConfirm(true);
+    setTimeout(() => setSendConfirm(false), 400);
     onSubmit(trimmed);
     setInput("");
     inputRef.current?.focus();
@@ -114,6 +147,11 @@ const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus", detec
 
   const hasOnlyWelcome = messages.length === 1;
 
+  // Find follow-ups from the last GM message
+  const lastGmMessage = [...messages].reverse().find((m) => m.sender !== "You");
+  const followUps = lastGmMessage?.followUps ?? [];
+  const showFollowUps = !thinking && followUps.length > 0 && !hasOnlyWelcome;
+
   return (
     <div className="panel flex flex-col h-full min-h-0 overflow-hidden">
 
@@ -124,7 +162,7 @@ const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus", detec
       >
         {/* GM avatar */}
         <span
-          className="inline-flex items-center justify-center w-8 h-8 rounded-full shrink-0"
+          className={`inline-flex items-center justify-center w-8 h-8 rounded-full shrink-0 ${avatarPulse ? "avatar-pulse" : ""}`}
           style={{
             background: `${gmColor}20`,
             border: `1.5px solid ${gmColor}55`,
@@ -163,7 +201,7 @@ const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus", detec
       {/* ── Messages ── */}
       <div className="flex-1 overflow-y-auto min-h-0 px-3 py-3 space-y-2.5">
 
-        {/* Welcome state — show quick-start prompts when only the intro message exists */}
+        {/* Welcome state — show when only the intro message exists */}
         {hasOnlyWelcome && (
           <div className="flex justify-start">
             <span
@@ -186,6 +224,7 @@ const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus", detec
 
         {!hasOnlyWelcome && messages.map((msg, i) => {
           const isUser = msg.sender === "You";
+          const isLastGm = !isUser && i === messages.length - 1;
           return (
             <div
               key={i}
@@ -197,27 +236,63 @@ const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus", detec
                   style={{ background: gmColor, minHeight: "1rem" }}
                 />
               )}
-              <div
-                className="max-w-[88%] text-sm leading-relaxed rounded-xl px-3.5 py-2.5"
-                style={
-                  isUser
-                    ? {
-                        background: "var(--c-raised)",
-                        border: "1px solid var(--c-border-mid)",
-                        color: "var(--c-text)",
-                        borderBottomRightRadius: "4px",
-                      }
-                    : {
-                        background: "var(--c-hover)",
-                        border: "1px solid var(--c-border-mid)",
-                        color: "var(--c-text)",
-                        borderBottomLeftRadius: "4px",
-                      }
-                }
-              >
-                {isUser
-                  ? msg.text
-                  : renderChessText(msg.text, gmColor)}
+              <div className="flex flex-col max-w-[88%] gap-1.5">
+                <div
+                  className="text-sm leading-relaxed rounded-xl px-3.5 py-2.5"
+                  style={
+                    isUser
+                      ? {
+                          background: "var(--c-raised)",
+                          border: "1px solid var(--c-border-mid)",
+                          color: "var(--c-text)",
+                          borderBottomRightRadius: "4px",
+                        }
+                      : {
+                          background: "var(--c-hover)",
+                          border: "1px solid var(--c-border-mid)",
+                          color: "var(--c-text)",
+                          borderBottomLeftRadius: "4px",
+                        }
+                  }
+                >
+                  {isUser
+                    ? msg.text
+                    : renderChessText(msg.text, gmColor, onMoveClick)}
+                </div>
+
+                {/* Follow-up chips under the last GM message */}
+                {isLastGm && showFollowUps && (
+                  <div className="flex flex-wrap gap-1.5 mt-0.5">
+                    {followUps.map((q, qi) => (
+                      <button
+                        key={qi}
+                        onClick={() => onSubmit(q)}
+                        disabled={thinking}
+                        className="chip-in text-xs px-2.5 py-1 rounded-full disabled:opacity-40"
+                        style={{
+                          background: "var(--c-raised)",
+                          border: `1px solid ${gmColor}33`,
+                          color: gmColor,
+                          fontFamily: "var(--f-sans)",
+                          whiteSpace: "nowrap",
+                          transition: "background 150ms ease, border-color 150ms ease",
+                          cursor: "pointer",
+                          animationDelay: `${qi * 0.07}s`,
+                        }}
+                        onMouseEnter={(e) => {
+                          (e.currentTarget as HTMLButtonElement).style.background = `${gmColor}18`;
+                          (e.currentTarget as HTMLButtonElement).style.borderColor = gmColor;
+                        }}
+                        onMouseLeave={(e) => {
+                          (e.currentTarget as HTMLButtonElement).style.background = "var(--c-raised)";
+                          (e.currentTarget as HTMLButtonElement).style.borderColor = `${gmColor}33`;
+                        }}
+                      >
+                        {q}
+                      </button>
+                    ))}
+                  </div>
+                )}
               </div>
             </div>
           );
@@ -348,13 +423,14 @@ const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus", detec
         <button
           onClick={handleSend}
           disabled={!input.trim() || thinking}
-          className="shrink-0 px-4 py-2.5 rounded-lg text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed"
+          className={`shrink-0 px-4 py-2.5 rounded-lg text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed ${sendConfirm ? "send-confirm" : ""}`}
           style={{
             background: `${gmColor}22`,
             border: `1px solid ${gmColor}66`,
-            color: gmColor,
+            color: sendConfirm ? "var(--c-text)" : gmColor,
             fontFamily: "var(--f-sans)",
             transition: "background 150ms ease, box-shadow 150ms ease, transform 80ms ease",
+            minWidth: "56px",
           }}
           onMouseEnter={(e) => {
             if (!(e.currentTarget as HTMLButtonElement).disabled) {
@@ -375,7 +451,7 @@ const ChatWindow = ({ messages, onSubmit, thinking, selectedGM = "Magnus", detec
             (e.currentTarget as HTMLButtonElement).style.transform = "scale(1)";
           }}
         >
-          Send
+          {sendConfirm ? "✓" : "Send"}
         </button>
       </div>
     </div>

--- a/src/components/ChessBoard.tsx
+++ b/src/components/ChessBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, useEffect } from "react";
+import React, { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { Chess } from "chess.js";
 import { Chessboard } from "react-chessboard";
 import type {
@@ -37,6 +37,7 @@ const ChessBoard: React.FC<ChessBoardProps> = ({
     from: Square;
     to: Square;
   } | null>(null);
+  const isDragging = useRef(false);
 
   useEffect(() => {
     setSelectedSquare(null);
@@ -110,6 +111,8 @@ const ChessBoard: React.FC<ChessBoardProps> = ({
 
   const handleSquareClick = useCallback(
     (square: Square) => {
+      // Ignore click events that are the tail of a drag operation
+      if (isDragging.current) return;
       const chess = new Chess(position);
 
       if (!selectedSquare) {
@@ -152,13 +155,18 @@ const ChessBoard: React.FC<ChessBoardProps> = ({
   );
 
   const handlePieceDragBegin = useCallback(
-    (_piece: Piece, square: Square) => { selectSquare(square); },
+    (_piece: Piece, square: Square) => {
+      isDragging.current = true;
+      selectSquare(square);
+    },
     [selectSquare]
   );
 
   const handlePieceDragEnd = useCallback(() => {
     setSelectedSquare(null);
     setLegalMoveSquares([]);
+    // Keep isDragging true briefly so the following click event is suppressed
+    setTimeout(() => { isDragging.current = false; }, 50);
   }, []);
 
   const handlePromotionPieceSelect = useCallback(
@@ -178,6 +186,7 @@ const ChessBoard: React.FC<ChessBoardProps> = ({
   return (
     <div
       className="w-full rounded-lg overflow-hidden"
+      onContextMenu={(e) => e.preventDefault()}
       style={{
         background: "var(--c-raised)",
         boxShadow: "0 8px 32px rgba(0,0,0,0.6), 0 2px 8px rgba(0,0,0,0.4)",

--- a/src/components/EngineLines.tsx
+++ b/src/components/EngineLines.tsx
@@ -6,9 +6,7 @@ interface EngineLinesProps {
   topLines: EngineLineResult[];
   currentFen: string;
   thinking: boolean;
-  /** Index of selected line (0-based), -1 = none */
   selectedLine: number;
-  /** Current preview step within selected line, -1 = not stepping */
   pvStep: number;
   onSelectLine: (i: number) => void;
   onPvStep: (dir: 1 | -1) => void;
@@ -16,39 +14,36 @@ interface EngineLinesProps {
 }
 
 const LINE_THEME = [
-  {
-    color: "var(--c-line1)",
-    bg: "var(--c-line1-bg)",
-    border: "var(--c-line1-border)",
-    label: "Best",
-  },
-  {
-    color: "var(--c-line2)",
-    bg: "var(--c-line2-bg)",
-    border: "var(--c-line2-border)",
-    label: "Alt",
-  },
-  {
-    color: "var(--c-line3)",
-    bg: "var(--c-line3-bg)",
-    border: "var(--c-line3-border)",
-    label: "Alt",
-  },
+  { color: "var(--c-line1)", bg: "var(--c-line1-bg)", border: "var(--c-line1-border)" },
+  { color: "var(--c-line2)", bg: "var(--c-line2-bg)", border: "var(--c-line2-border)" },
+  { color: "var(--c-line3)", bg: "var(--c-line3-bg)", border: "var(--c-line3-border)" },
 ];
 
 function formatEval(score: number | null, mate: number | null): string {
-  if (mate !== null) return mate > 0 ? `M${mate}` : `M${Math.abs(mate)}`;
+  if (mate !== null) return mate > 0 ? `M${mate}` : `-M${Math.abs(mate)}`;
   if (score === null) return "—";
   if (score >= 9999) return "M";
-  if (score <= -9999) return "M";
+  if (score <= -9999) return "-M";
   const abs = Math.abs(score / 100).toFixed(2);
   return score > 0 ? `+${abs}` : score < 0 ? `-${abs}` : "0.00";
+}
+
+function evalLabel(score: number | null, mate: number | null): string {
+  if (mate !== null) return mate > 0 ? "Winning" : "Losing";
+  if (score === null) return "Unknown";
+  if (score >= 300)  return "Winning";
+  if (score >= 100)  return "Advantage";
+  if (score >= 25)   return "Slight edge";
+  if (score > -25)   return "Equal";
+  if (score > -100)  return "Slight risk";
+  if (score > -300)  return "Disadvantage";
+  return "Losing";
 }
 
 interface LineToken {
   text: string;
   kind: "number" | "move";
-  moveIdx: number; // which pv index this move corresponds to (-1 for number tokens)
+  moveIdx: number;
 }
 
 function buildTokens(fen: string, pvMoves: string[], maxMoves = 6): LineToken[] {
@@ -66,16 +61,12 @@ function buildTokens(fen: string, pvMoves: string[], maxMoves = 6): LineToken[] 
         tokens.push({ text: `${moveNum}…`, kind: "number", moveIdx: -1 });
       }
 
-      const result = chess.move({
-        from: uci.slice(0, 2),
-        to: uci.slice(2, 4),
-        promotion: uci[4] ?? "q",
-      });
+      const result = chess.move({ from: uci.slice(0, 2), to: uci.slice(2, 4), promotion: uci[4] ?? "q" });
       if (!result) return;
 
       tokens.push({ text: result.san, kind: "move", moveIdx: i });
     } catch {
-      // Stop on illegal move
+      // stop on illegal move
     }
   });
 
@@ -96,7 +87,8 @@ const EngineLines: React.FC<EngineLinesProps> = ({
     return topLines.map((line) => ({
       ...line,
       evalStr: formatEval(line.score, line.mate),
-      tokens: buildTokens(currentFen, line.pv),
+      label: evalLabel(line.score, line.mate),
+      tokens: buildTokens(currentFen, line.pv, 7),
     }));
   }, [topLines, currentFen]);
 
@@ -121,7 +113,7 @@ const EngineLines: React.FC<EngineLinesProps> = ({
             {[0, 1, 2].map((i) => (
               <span
                 key={i}
-                className={`thinking-bar inline-block w-0.5 rounded-full`}
+                className="thinking-bar inline-block w-0.5 rounded-full"
                 style={{
                   height: i === 1 ? "10px" : "6px",
                   background: "var(--c-text-muted)",
@@ -133,8 +125,8 @@ const EngineLines: React.FC<EngineLinesProps> = ({
         )}
       </div>
 
-      {/* ── Lines ── */}
-      <div className="p-2 space-y-1">
+      {/* ── Move cards ── */}
+      <div className="p-2 space-y-1.5">
         {processedLines.length === 0 ? (
           <div
             className="py-4 text-center text-xs"
@@ -147,53 +139,98 @@ const EngineLines: React.FC<EngineLinesProps> = ({
             const theme = LINE_THEME[i] ?? LINE_THEME[2];
             const isSelected = selectedLine === i;
 
+            // Split tokens: first move vs rest
+            const firstMoveToken = line.tokens.find((t) => t.kind === "move" && t.moveIdx === 0);
+            const restTokens = line.tokens.filter((t) => t !== firstMoveToken || t.moveIdx !== 0);
+            // Number token before the first move (may be the very first token)
+            const numToken = line.tokens[0]?.kind === "number" ? line.tokens[0] : null;
+
             return (
               <button
                 key={i}
                 onClick={() => onSelectLine(isSelected ? -1 : i)}
-                className="w-full text-left px-3 py-2 rounded-lg transition-all duration-150 group"
+                className="w-full text-left rounded-lg transition-all duration-150 engine-card overflow-hidden"
                 style={{
-                  background: isSelected ? theme.bg : "transparent",
-                  border: `1px solid ${isSelected ? theme.border : "transparent"}`,
+                  background: isSelected ? theme.bg : "var(--c-surface)",
+                  border: `1px solid ${isSelected ? theme.border : "var(--c-border)"}`,
                 }}
               >
-                <div className="flex items-start gap-3 min-w-0">
-                  {/* Eval badge */}
-                  <span
-                    className="text-xs font-semibold tabular-nums shrink-0 mt-0.5 w-11 text-right"
-                    style={{ color: theme.color, fontFamily: "var(--f-mono)" }}
-                  >
-                    {line.evalStr}
-                  </span>
+                {/* ── Card top: eval + first move ── */}
+                <div className="flex items-center gap-2.5 px-3 py-2">
+                  {/* Eval section */}
+                  <div className="flex flex-col items-start shrink-0" style={{ minWidth: "80px" }}>
+                    <span
+                      className="text-xs font-semibold tabular-nums leading-tight"
+                      style={{ color: theme.color, fontFamily: "var(--f-mono)" }}
+                    >
+                      {line.evalStr}
+                    </span>
+                    <span
+                      className="text-xs leading-tight mt-0.5"
+                      style={{ color: "var(--c-text-muted)", fontFamily: "var(--f-sans)", fontSize: "10px" }}
+                    >
+                      {line.label}
+                    </span>
+                  </div>
 
-                  {/* Move tokens */}
-                  <span
-                    className="text-xs leading-relaxed flex flex-wrap gap-x-1 min-w-0"
-                    style={{ fontFamily: "var(--f-mono)" }}
+                  {/* Divider */}
+                  <div className="self-stretch w-px shrink-0" style={{ background: theme.border, opacity: 0.6 }} />
+
+                  {/* First move — prominent */}
+                  <div className="flex items-baseline gap-1 min-w-0">
+                    {numToken && (
+                      <span
+                        className="text-xs"
+                        style={{ color: "var(--c-text-muted)", fontFamily: "var(--f-mono)" }}
+                      >
+                        {numToken.text}
+                      </span>
+                    )}
+                    {firstMoveToken && (
+                      <span
+                        className="font-bold rounded px-1"
+                        style={{
+                          fontFamily: "var(--f-mono)",
+                          fontSize: "15px",
+                          color: isSelected ? "#fff" : theme.color,
+                          background: isSelected ? theme.color : `${theme.color}15`,
+                          letterSpacing: "0.01em",
+                          transition: "background 150ms ease, color 150ms ease",
+                        }}
+                      >
+                        {firstMoveToken.text}
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                {/* ── Card bottom: continuation ── */}
+                {restTokens.some((t) => t.kind === "move") && (
+                  <div
+                    className="flex flex-wrap gap-x-1 px-3 pb-2 pt-0"
+                    style={{ borderTop: `1px solid ${theme.border}`, paddingTop: "5px" }}
                   >
-                    {line.tokens.map((token, j) => {
+                    {restTokens.map((token, j) => {
                       const isMoveActive = isSelected && token.moveIdx === pvStep;
-                      const isFirstMove = token.moveIdx === 0;
-
                       if (token.kind === "number") {
                         return (
-                          <span key={j} style={{ color: "var(--c-text-muted)" }}>
+                          <span
+                            key={j}
+                            className="text-xs"
+                            style={{ color: "var(--c-text-muted)", fontFamily: "var(--f-mono)" }}
+                          >
                             {token.text}
                           </span>
                         );
                       }
-
                       return (
                         <span
                           key={j}
-                          className="rounded px-0.5 transition-colors"
+                          className="text-xs rounded px-0.5 transition-colors"
                           style={{
-                            color: isMoveActive
-                              ? "#fff"
-                              : isFirstMove
-                              ? "var(--c-text)"
-                              : "var(--c-text-soft)",
-                            fontWeight: isFirstMove ? 600 : 400,
+                            fontFamily: "var(--f-mono)",
+                            color: isMoveActive ? "#fff" : "var(--c-text-soft)",
+                            fontWeight: isMoveActive ? 600 : 400,
                             background: isMoveActive ? theme.color : "transparent",
                           }}
                         >
@@ -201,35 +238,27 @@ const EngineLines: React.FC<EngineLinesProps> = ({
                         </span>
                       );
                     })}
-                  </span>
-                </div>
+                  </div>
+                )}
               </button>
             );
           })
         )}
       </div>
 
-      {/* ── Step controls (visible when a line is selected) ── */}
+      {/* ── Step controls ── */}
       {selectedLine >= 0 && (
         <div
           className="flex items-center gap-2 px-3 py-2.5 flex-wrap"
           style={{ borderTop: "1px solid var(--c-border)" }}
         >
-          <button
-            className="btn text-xs px-2 py-1"
-            onClick={() => onPvStep(-1)}
-            disabled={pvStep <= 0}
-          >
+          <button className="btn text-xs px-2 py-1" onClick={() => onPvStep(-1)} disabled={pvStep <= 0}>
             ← Prev
           </button>
-          <button
-            className="btn text-xs px-2 py-1"
-            onClick={() => onPvStep(1)}
-            disabled={pvStep >= activePvLength - 1}
-          >
+          <button className="btn text-xs px-2 py-1" onClick={() => onPvStep(1)} disabled={pvStep >= activePvLength - 1}>
             Next →
           </button>
-          {isPreviewing && (
+          {isPreviewing ? (
             <>
               <span
                 className="text-xs tabular-nums"
@@ -245,12 +274,14 @@ const EngineLines: React.FC<EngineLinesProps> = ({
                 ✕ Exit
               </button>
             </>
-          )}
-          {!isPreviewing && (
+          ) : (
             <button
               className="btn text-xs px-2 py-1"
               onClick={() => onPvStep(1)}
-              style={{ borderColor: LINE_THEME[selectedLine]?.color, color: LINE_THEME[selectedLine]?.color }}
+              style={{
+                borderColor: LINE_THEME[selectedLine]?.color,
+                color: LINE_THEME[selectedLine]?.color,
+              }}
             >
               ▶ Step through
             </button>
@@ -259,15 +290,9 @@ const EngineLines: React.FC<EngineLinesProps> = ({
       )}
 
       {/* ── Footer ── */}
-      {!selectedLine && selectedLine !== 0 && (
-        <div
-          className="px-4 py-2"
-          style={{ borderTop: "1px solid var(--c-border)" }}
-        >
-          <p
-            className="text-xs"
-            style={{ color: "var(--c-text-muted)", fontFamily: "var(--f-mono)" }}
-          >
+      {selectedLine < 0 && (
+        <div className="px-4 py-2" style={{ borderTop: "1px solid var(--c-border)" }}>
+          <p className="text-xs" style={{ color: "var(--c-text-muted)", fontFamily: "var(--f-mono)" }}>
             GM advice is grounded in these lines
           </p>
         </div>

--- a/src/components/EvalBar.tsx
+++ b/src/components/EvalBar.tsx
@@ -79,7 +79,7 @@ const EvalBar: React.FC<EvalBarProps> = ({ evalScore, mateIn, thinking }) => {
         style={{
           color: labelColor,
           fontFamily: "var(--f-mono)",
-          fontSize: "10px",
+          fontSize: "15px",
           fontWeight: 600,
           opacity: isLoading ? 0.3 : 1,
           letterSpacing: "0.02em",

--- a/src/components/PositionBrief.tsx
+++ b/src/components/PositionBrief.tsx
@@ -1,0 +1,142 @@
+import React, { useMemo } from "react";
+import { Chess } from "chess.js";
+import type { DetectedOpening } from "../utils/openingDetection";
+
+interface PositionBriefProps {
+  fen: string;
+  evalScore: number | null;
+  mateIn: number | null;
+  detectedOpening: DetectedOpening | null;
+}
+
+function evalLabel(score: number | null, mate: number | null): string {
+  if (mate !== null) return mate > 0 ? "Winning" : "Losing";
+  if (score === null) return "";
+  const abs = Math.abs(score);
+  if (score >= 300)  return "Winning";
+  if (score >= 100)  return "Advantage";
+  if (score >= 25)   return "Slight edge";
+  if (abs <= 24)     return "Equal";
+  if (score > -100)  return "Slight risk";
+  if (score > -300)  return "Disadvantage";
+  return "Losing";
+}
+
+function evalLabelColor(score: number | null, mate: number | null): string {
+  if (mate !== null) return mate > 0 ? "var(--c-line1)" : "var(--c-gm-bobby)";
+  if (score === null) return "var(--c-text-muted)";
+  if (score >= 100)  return "var(--c-line1)";
+  if (score >= 25)   return "var(--c-line1)";
+  if (score > -25)   return "var(--c-text-soft)";
+  if (score > -100)  return "var(--c-line2)";
+  return "var(--c-gm-bobby)";
+}
+
+function getMaterialBalance(fen: string): string {
+  const PIECE_VALUES: Record<string, number> = { p: 1, n: 3, b: 3, r: 5, q: 9 };
+  try {
+    const chess = new Chess(fen);
+    let w = 0, b = 0;
+    for (const row of chess.board()) {
+      for (const piece of row) {
+        if (!piece || piece.type === "k") continue;
+        const val = PIECE_VALUES[piece.type] ?? 0;
+        if (piece.color === "w") w += val; else b += val;
+      }
+    }
+    const diff = w - b;
+    if (diff === 0) return "";
+    const side = diff > 0 ? "W" : "B";
+    return `${side}+${Math.abs(diff)}`;
+  } catch {
+    return "";
+  }
+}
+
+const PositionBrief: React.FC<PositionBriefProps> = ({ fen, evalScore, mateIn, detectedOpening }) => {
+  const { moveNum, sideToMove, label, labelColor, material, openingShort } = useMemo(() => {
+    let moveNum = 1;
+    let sideToMove = "W";
+    try {
+      const chess = new Chess(fen);
+      moveNum = chess.moveNumber();
+      sideToMove = chess.turn() === "w" ? "W" : "B";
+    } catch { /* ignore */ }
+
+    const label = evalLabel(evalScore, mateIn);
+    const labelColor = evalLabelColor(evalScore, mateIn);
+    const material = getMaterialBalance(fen);
+    const openingShort = detectedOpening
+      ? detectedOpening.name.split(" — ")[0]
+      : null;
+
+    return { moveNum, sideToMove, label, labelColor, material, openingShort };
+  }, [fen, evalScore, mateIn, detectedOpening]);
+
+  return (
+    <div
+      className="flex items-center gap-2 px-3 py-1.5 overflow-hidden"
+      style={{
+        background: "var(--c-surface)",
+        borderBottom: "1px solid var(--c-border)",
+        fontFamily: "var(--f-mono)",
+      }}
+    >
+      {/* Move number + side */}
+      <span className="text-xs shrink-0" style={{ color: "var(--c-text-muted)" }}>
+        <span style={{ color: "var(--c-text-soft)" }}>#{moveNum}</span>
+        <span className="mx-1" style={{ opacity: 0.4 }}>·</span>
+        <span
+          className="font-semibold"
+          style={{ color: sideToMove === "W" ? "#F0E8D8" : "var(--c-text-muted)" }}
+        >
+          {sideToMove}
+        </span>
+      </span>
+
+      {/* Eval label */}
+      {label && (
+        <>
+          <span style={{ color: "var(--c-border-bright)", fontSize: "10px" }}>|</span>
+          <span
+            className="text-xs font-semibold shrink-0"
+            style={{ color: labelColor }}
+          >
+            {label}
+          </span>
+        </>
+      )}
+
+      {/* Material */}
+      {material && (
+        <>
+          <span style={{ color: "var(--c-border-bright)", fontSize: "10px" }}>|</span>
+          <span className="text-xs shrink-0" style={{ color: "var(--c-text-muted)" }}>
+            {material}
+          </span>
+        </>
+      )}
+
+      {/* Opening name — desktop: full, mobile: truncated */}
+      {openingShort && (
+        <>
+          <span className="hidden sm:inline" style={{ color: "var(--c-border-bright)", fontSize: "10px" }}>|</span>
+          <span
+            className="hidden sm:inline text-xs overflow-hidden text-ellipsis whitespace-nowrap"
+            style={{
+              color: "var(--c-gold)",
+              fontFamily: "var(--f-sans)",
+              minWidth: 0,
+              maxWidth: "180px",
+            }}
+            title={detectedOpening?.name}
+          >
+            {openingShort}
+          </span>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default PositionBrief;

--- a/src/features/ChessPanel.tsx
+++ b/src/features/ChessPanel.tsx
@@ -1,12 +1,14 @@
-import React, { useState, useCallback, useMemo } from "react";
+import React, { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { Chess } from "chess.js";
 import ChessBoard from "../components/ChessBoard";
 import EvalBar from "../components/EvalBar";
 import CapturedPieces from "../components/CapturedPieces";
 import EngineLines from "../components/EngineLines";
 import MoveNotation from "../components/MoveNotation";
+import PositionBrief from "../components/PositionBrief";
 import type { Arrow } from "react-chessboard/dist/chessboard/types";
 import type { EngineLineResult } from "../hooks/useStockfish";
+import type { DetectedOpening } from "../utils/openingDetection";
 
 interface ChessPanelProps {
   position: string;
@@ -28,6 +30,7 @@ interface ChessPanelProps {
   sanMoves: string[];
   historyIndex: number;
   onNavigate: (index: number) => void;
+  detectedOpening?: DetectedOpening | null;
 }
 
 const GM_COLORS: Record<string, string> = {
@@ -56,10 +59,23 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
   sanMoves,
   historyIndex,
   onNavigate,
+  detectedOpening,
 }) => {
   const [boardFlipped, setBoardFlipped] = useState(false);
   const [selectedLine, setSelectedLine] = useState(-1);
   const [pvStep, setPvStep] = useState(-1);
+  const [boardReady, setBoardReady] = useState(false);
+  const prevThinkingRef = useRef(engineThinking);
+
+  // Trigger analysis-ready ring when engine finishes
+  useEffect(() => {
+    if (prevThinkingRef.current && !engineThinking && topLines.length > 0) {
+      setBoardReady(true);
+      const t = setTimeout(() => setBoardReady(false), 750);
+      return () => clearTimeout(t);
+    }
+    prevThinkingRef.current = engineThinking;
+  }, [engineThinking, topLines.length]);
 
   const isPreviewing = selectedLine >= 0 && pvStep >= 0;
 
@@ -114,11 +130,19 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
 
   return (
     <div
-      className="panel p-3 w-full"
+      className="panel w-full overflow-hidden"
       style={{ boxShadow: "0 16px 48px rgba(0,0,0,0.6)" }}
     >
+      {/* ── Position Brief strip ── */}
+      <PositionBrief
+        fen={position}
+        evalScore={evalScore}
+        mateIn={mateIn}
+        detectedOpening={detectedOpening ?? null}
+      />
+
       {/* ── Board + eval bar row ── */}
-      <div className="flex gap-2 items-stretch">
+      <div className="flex gap-2 items-stretch p-3 pb-0">
         {/* Eval bar — desktop vertical */}
         <div className="hidden md:flex items-stretch w-4 shrink-0">
           <EvalBar evalScore={evalScore} mateIn={mateIn} thinking={engineThinking} />
@@ -127,30 +151,32 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
         {/* Board column */}
         <div className="flex-1 flex flex-col min-w-0 gap-1">
           <CapturedPieces fen={position} side="top" />
-          <ChessBoard
-            key={isPreviewing ? `pv-${selectedLine}-${pvStep}` : "game"}
-            position={isPreviewing && previewFen ? previewFen : position}
-            onMove={isPreviewing ? () => false : onMove}
-            lastMove={isPreviewing ? previewLastMove : lastMove}
-            inCheck={inCheck}
-            kingInCheckSquare={kingInCheckSquare}
-            engineArrow={isPreviewing ? null : engineArrow}
-            animationDuration={isPreviewing ? 0 : 200}
-            boardOrientation={boardFlipped ? "black" : "white"}
-          />
+          <div className={boardReady ? "analysis-ready rounded-lg" : ""}>
+            <ChessBoard
+              key={isPreviewing ? `pv-${selectedLine}-${pvStep}` : "game"}
+              position={isPreviewing && previewFen ? previewFen : position}
+              onMove={isPreviewing ? () => false : onMove}
+              lastMove={isPreviewing ? previewLastMove : lastMove}
+              inCheck={inCheck}
+              kingInCheckSquare={kingInCheckSquare}
+              engineArrow={isPreviewing ? null : engineArrow}
+              animationDuration={isPreviewing ? 0 : 200}
+              boardOrientation={boardFlipped ? "black" : "white"}
+            />
+          </div>
           <CapturedPieces fen={position} side="bottom" />
         </div>
       </div>
 
       {/* ── Eval bar — mobile horizontal ── */}
-      <div className="md:hidden mt-2 px-1">
+      <div className="md:hidden mt-2 px-3 px-1">
         <EvalBar evalScore={evalScore} mateIn={mateIn} thinking={engineThinking} />
       </div>
 
       {/* ── Move notation ── */}
       {sanMoves.length > 0 && (
         <div
-          className="mt-3 pt-3 px-1"
+          className="mt-3 pt-3 px-3 pb-0"
           style={{ borderTop: "1px solid var(--c-border)" }}
         >
           <MoveNotation
@@ -162,7 +188,7 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
       )}
 
       {/* ── Engine lines ── */}
-      <div className="mt-3">
+      <div className="mt-3 px-3 pb-0">
         <EngineLines
           topLines={topLines}
           currentFen={position}
@@ -177,7 +203,7 @@ const ChessPanel: React.FC<ChessPanelProps> = ({
 
       {/* ── Control buttons ── */}
       <div
-        className="flex flex-wrap items-center gap-1.5 mt-3 pt-3"
+        className="flex flex-wrap items-center gap-1.5 mt-3 pt-3 px-3 pb-3"
         style={{ borderTop: "1px solid var(--c-border)" }}
       >
         {/* Navigation group */}

--- a/src/index.css
+++ b/src/index.css
@@ -2,32 +2,32 @@
 @import "tailwindcss";
 
 :root {
-  /* ── Backgrounds ── */
-  --c-bg:       #08080E;
-  --c-surface:  #0E0E17;
-  --c-raised:   #151521;
-  --c-hover:    #1C1C2A;
+  /* ── Backgrounds — pure charcoal, zero color cast ── */
+  --c-bg:       #0A0A0A;
+  --c-surface:  #111111;
+  --c-raised:   #1A1A1A;
+  --c-hover:    #222222;
 
-  /* ── Borders ── */
-  --c-border:        #1A1A2A;
-  --c-border-mid:    #242438;
-  --c-border-bright: #303048;
+  /* ── Borders — pure gray ── */
+  --c-border:        #1E1E1E;
+  --c-border-mid:    #2A2A2A;
+  --c-border-bright: #383838;
 
-  /* ── Gold accent — brass lamp in a mahogany study ── */
-  --c-gold:       #C89040;
-  --c-gold-bright:#E4A84C;
-  --c-gold-dim:   rgba(200, 144, 64, 0.14);
-  --c-gold-glow:  rgba(200, 144, 64, 0.08);
-  --c-gold-ring:  rgba(200, 144, 64, 0.35);
+  /* ── Amber accent — single electric accent ── */
+  --c-gold:       #D4820A;
+  --c-gold-bright:#E8960E;
+  --c-gold-dim:   rgba(212, 130, 10, 0.14);
+  --c-gold-glow:  rgba(212, 130, 10, 0.08);
+  --c-gold-ring:  rgba(212, 130, 10, 0.35);
 
-  /* ── Interactive blue ── */
-  --c-blue:     #4674E8;
-  --c-blue-dim: rgba(70, 116, 232, 0.12);
+  /* ── Interactive (kept for compatibility) ── */
+  --c-blue:     #4A7AE8;
+  --c-blue-dim: rgba(74, 122, 232, 0.12);
 
-  /* ── Engine line colors — tactical beams ── */
-  --c-line1:        #38C87A;
-  --c-line1-bg:     rgba(56, 200, 122, 0.07);
-  --c-line1-border: rgba(56, 200, 122, 0.22);
+  /* ── Engine line colors ── */
+  --c-line1:        #3FC87A;
+  --c-line1-bg:     rgba(63, 200, 122, 0.07);
+  --c-line1-border: rgba(63, 200, 122, 0.22);
 
   --c-line2:        #E89C20;
   --c-line2-bg:     rgba(232, 156, 32, 0.06);
@@ -38,14 +38,14 @@
   --c-line3-border: rgba(104, 128, 164, 0.16);
 
   /* ── GM identity colors ── */
-  --c-gm-magnus: #4674E8;
-  --c-gm-hikaru: #E87C20;
-  --c-gm-bobby:  #C84848;
+  --c-gm-magnus: #4A7AE8;
+  --c-gm-hikaru: #E88020;
+  --c-gm-bobby:  #D44040;
 
   /* ── Text ── */
-  --c-text:       #DDD8CF;
-  --c-text-soft:  #8A8898;
-  --c-text-muted: #4C4A5C;
+  --c-text:       #F0F0F0;
+  --c-text-soft:  #888888;
+  --c-text-muted: #444444;
 
   /* ── Typography ── */
   --f-serif: 'Cormorant Garamond', Georgia, serif;
@@ -53,9 +53,9 @@
   --f-sans:  'DM Sans', system-ui, sans-serif;
 
   /* ── Transitions ── */
-  --t-fast:   100ms ease;
-  --t-base:   150ms ease;
-  --t-slow:   250ms ease;
+  --t-fast: 100ms ease;
+  --t-base: 150ms ease;
+  --t-slow: 250ms ease;
 }
 
 *, *::before, *::after {
@@ -65,6 +65,9 @@
 html, body, #root {
   height: 100%;
   margin: 0;
+  /* Safe area for iPhone notch / Dynamic Island */
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 body {
@@ -83,7 +86,7 @@ body {
 }
 
 /* ── Refined scrollbars ── */
-::-webkit-scrollbar { width: 4px; height: 4px; }
+::-webkit-scrollbar       { width: 3px; height: 3px; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb {
   background: var(--c-border-bright);
@@ -109,8 +112,11 @@ body {
     color: var(--c-text-soft);
     font-family: var(--f-sans);
     letter-spacing: 0.01em;
-    transition: background var(--t-base), border-color var(--t-base), color var(--t-base), box-shadow var(--t-base), transform var(--t-fast);
+    transition: background var(--t-base), border-color var(--t-base),
+                color var(--t-base), box-shadow var(--t-base), transform var(--t-fast);
     cursor: pointer;
+    /* Ensure 44px min tap target on touch */
+    min-height: 36px;
   }
   .btn:hover:not(:disabled) {
     background: var(--c-hover);
@@ -118,13 +124,8 @@ body {
     color: var(--c-gold-bright);
     box-shadow: 0 0 0 1px var(--c-gold-glow);
   }
-  .btn:active:not(:disabled) {
-    transform: scale(0.97);
-  }
-  .btn:disabled {
-    cursor: not-allowed;
-    opacity: 0.35;
-  }
+  .btn:active:not(:disabled) { transform: scale(0.97); }
+  .btn:disabled { cursor: not-allowed; opacity: 0.35; }
   .btn:focus-visible {
     outline: 2px solid var(--c-gold-ring);
     outline-offset: 2px;
@@ -139,18 +140,14 @@ body {
     letter-spacing: 0.01em;
     transition: background var(--t-base), box-shadow var(--t-base), transform var(--t-fast);
     cursor: pointer;
+    min-height: 36px;
   }
   .btn-primary:hover:not(:disabled) {
-    background: rgba(200, 144, 64, 0.22);
+    background: rgba(212, 130, 10, 0.22);
     box-shadow: 0 0 12px var(--c-gold-glow);
   }
-  .btn-primary:active:not(:disabled) {
-    transform: scale(0.97);
-  }
-  .btn-primary:disabled {
-    cursor: not-allowed;
-    opacity: 0.35;
-  }
+  .btn-primary:active:not(:disabled) { transform: scale(0.97); }
+  .btn-primary:disabled { cursor: not-allowed; opacity: 0.35; }
 
   .panel {
     background: var(--c-surface);
@@ -158,9 +155,24 @@ body {
     border-radius: 0.875rem;
     transition: border-color var(--t-slow);
   }
-  .panel:focus-within {
-    border-color: var(--c-border-mid);
+  .panel:focus-within { border-color: var(--c-border-mid); }
+
+  /* Clickable move token inside GM chat responses */
+  .move-token {
+    font-family: var(--f-mono);
+    font-size: 0.85em;
+    font-weight: 600;
+    border-radius: 4px;
+    padding: 1px 4px;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    display: inline-block;
+    transition: background var(--t-base), color var(--t-base), transform var(--t-fast);
+    /* 28px min touch target height via line-height trick */
+    line-height: 1.6;
   }
+  .move-token:hover  { filter: brightness(1.2); transform: scale(1.04); }
+  .move-token:active { transform: scale(0.97); }
 }
 
 /* ── Thinking animation ── */
@@ -175,26 +187,61 @@ body {
 .thinking-bar:nth-child(2) { animation-delay: 0.18s; }
 .thinking-bar:nth-child(3) { animation-delay: 0.36s; }
 
-/* ── Fade-in for new chat messages ── */
+/* ── Message entrance animation ── */
 @keyframes msg-in {
-  from { opacity: 0; transform: translateY(6px); }
+  from { opacity: 0; transform: translateY(5px); }
   to   { opacity: 1; transform: translateY(0); }
 }
-.msg-in {
-  animation: msg-in 0.2s ease forwards;
-}
+.msg-in { animation: msg-in 0.18s ease forwards; }
 
-/* ── Opening badge pulse ── */
+/* ── Follow-up chip entrance ── */
+@keyframes chip-in {
+  from { opacity: 0; transform: translateX(-4px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+.chip-in { animation: chip-in 0.2s ease forwards; }
+
+/* ── Badge entrance ── */
 @keyframes badge-in {
   from { opacity: 0; transform: scale(0.92); }
   to   { opacity: 1; transform: scale(1); }
 }
-.badge-in {
-  animation: badge-in 0.25s ease forwards;
+.badge-in { animation: badge-in 0.25s ease forwards; }
+
+/* ── GM avatar pulse when response arrives ── */
+@keyframes avatar-pulse {
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.18); }
+  100% { transform: scale(1); }
 }
+.avatar-pulse { animation: avatar-pulse 0.35s ease; }
+
+/* ── Analysis-ready ring on board ── */
+@keyframes analysis-ready {
+  0%   { box-shadow: 0 0 0 0px rgba(63, 200, 122, 0.5); }
+  50%  { box-shadow: 0 0 0 4px rgba(63, 200, 122, 0.2); }
+  100% { box-shadow: 0 0 0 0px rgba(63, 200, 122, 0); }
+}
+.analysis-ready { animation: analysis-ready 0.7s ease forwards; }
+
+/* ── Send button confirm ── */
+@keyframes send-confirm {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.6; }
+}
+.send-confirm { animation: send-confirm 0.4s ease; }
 
 /* ── Smooth eval bar transition ── */
 .eval-fill {
-  transition: height 0.8s cubic-bezier(0.4, 0, 0.2, 1),
-              width  0.8s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: height 0.75s cubic-bezier(0.4, 0, 0.2, 1),
+              width  0.75s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ── Engine line card hover ── */
+.engine-card:hover { background: var(--c-hover) !important; }
+
+/* ── iPhone 16 Pro specific: min touch targets ── */
+@media (max-width: 430px) {
+  .btn { min-height: 40px; }
+  .panel { border-radius: 0.75rem; }
 }


### PR DESCRIPTION
Server:
- GM personalities: add in-character off-topic blocking (Magnus dry/deadpan, Hikaru streaming culture, Bobby intense/dismissive)
- Input sanitization: strip control chars, max 1000 chars, limit topLines/conversationHistory array sizes
- Question classifier: keyword-based detection (tactical/theory/conceptual) drives response length hint in system prompt
- Learning loop: model appends FOLLOWUPS: q1 | q2 | q3; server parses and strips before sending { response, followUps }
- Move validation: extract SAN tokens from response, check legality, retry once with correction prompt if illegal move found

Frontend:
- ChatWindow: clickable move tokens (onMoveClick → handleGMMove plays on board), follow-up chips below last GM message, send button ✓ confirmation, GM avatar pulse on new response
- EngineLines: redesigned as move cards — first move shown prominently at 15px, descriptive eval labels (Winning/Advantage/Slight edge/Equal/Slight risk/Disadvantage/Losing), continuation in smaller text
- EvalBar: eval score font 10px → 15px
- ChessBoard: onContextMenu preventDefault (fixes right-click arrow drawing on desktop), isDragging ref to suppress phantom click after drag-drop
- PositionBrief: new slim context strip showing move #, side to move, eval label, material balance, opening name
- ChessPanel: integrates PositionBrief, analysis-ready ring animation when engine finishes, padding layout cleanup
- App: ChatMessage extended with fen/followUps fields, handleGMMove callback, askGM returns { response, followUps }
- CSS: amber palette, pure charcoal backgrounds, move-token class, avatar-pulse/analysis-ready/send-confirm animations, iPhone safe-area insets

https://claude.ai/code/session_012dTPzKmBpGhWyBAkXzpNbv