### PR TITLE
feat: coaching quality & UI v2 — all 10 improvements

### DIFF
--- a/src/components/MoveNotation.tsx
+++ b/src/components/MoveNotation.tsx
@@ -117,7 +117,7 @@ interface MoveButtonProps {
   index: number;
   currentIndex: number;
   onNavigate: (index: number) => void;
-  activeRef?: React.RefObject<HTMLButtonElement | null>;
+  activeRef?: React.Ref<HTMLButtonElement>;
 }
 
 const MoveButton: React.FC<MoveButtonProps> = ({ san, index, currentIndex, onNavigate, activeRef }) => {


### PR DESCRIPTION
## Summary

- **Off-topic blocking**: each GM dismisses non-chess questions in character (Magnus dry/deadpan, Hikaru streaming culture, Bobby intense contempt)
- **Input sanitization**: control chars stripped, question capped at 1000 chars, `topLines` limited to 5, `conversationHistory` limited to 10
- **Question classifier**: detects tactical/theory/conceptual questions and injects a matching response-length hint into the system prompt
- **Learning loop**: model appends `FOLLOWUPS: q1 | q2 | q3`; server parses and returns `{ response, followUps }` — shown as chips below the last GM message
- **Move validation with retry**: SAN tokens extracted from response, checked against legal moves, retries once with a correction prompt if illegal moves found
- **Clickable move tokens**: chess moves in GM responses are tappable and play on the board
- **EngineLines redesign**: move card format — first move prominent at 15px, descriptive eval labels (Winning → Equal → Losing)
- **EvalBar**: score font 10px → 15px
- **ChessBoard**: `onContextMenu` preventDefault fixes right-click arrow drawing on desktop; `isDragging` ref fixes phantom click after drag
- **PositionBrief**: new slim strip above board showing move #, side to move, eval label, material balance, opening name
- **CSS**: amber palette, `move-token`, `avatar-pulse`, `analysis-ready`, `send-confirm` animations, iPhone safe-area insets
- **Markdown stripping**: system prompt instructs plain prose; `stripMarkdown()` sanitizer in ChatWindow strips any stray symbols before rendering — move tokens still highlighted correctly
- **TypeScript fix**: `MoveNotation.tsx` `activeRef` prop changed from `React.RefObject<HTMLButtonElement | null>` to `React.Ref<HTMLButtonElement>` to unblock Railway build

## Test plan

- [ ] Lint passes (`npm run lint`)
- [ ] Vite build passes (`node_modules/.bin/vite build`)
- [ ] Ask a non-chess question — GM dismisses in character
- [ ] GM response renders as plain conversational prose (no `**`, `#`, `- ` symbols)
- [ ] Chess moves in GM response are highlighted and clickable — clicking plays the move on the board
- [ ] Follow-up chips appear below last GM message and submit correctly
- [ ] Engine lines show move cards with descriptive eval labels
- [ ] Right-click on board draws arrows (no context menu)
- [ ] PositionBrief strip visible above board

https://claude.ai/code/session_012dTPzKmBpGhWyBAkXzpNbv

---
_Generated by [Claude Code](https://claude.ai/code/session_012dTPzKmBpGhWyBAkXzpNbv)_